### PR TITLE
chore(NuGet): update Microsoft.Extensions.Caching.Memory version to .NET Standard 2.0

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
+++ b/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>


### PR DESCRIPTION
chore(NuGet): update Microsoft.Extensions.Caching.Memory version to .NET Standard 2.0

Updates the `Microsoft.Extensions.Caching.Memory` NuGet package from 1.1.2 to 2.1.2 to ship a .NET Standard 2.0 binary instead of .NET Standard 1.3 binary