### PR TITLE
Fixes issue #9: C# SDK stops working after 20 minutes

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/Auth/SharedAccessSignatureTokenProvider.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Auth/SharedAccessSignatureTokenProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.NotificationHubs.Auth
     using Common;
     using System;
     using System.Text;
-
+    
     internal class SharedAccessSignatureTokenProvider : TokenProvider
     {
         private const int MaxKeyNameLength = 256;
@@ -18,9 +18,12 @@ namespace Microsoft.Azure.NotificationHubs.Auth
         internal readonly byte[] _encodedSharedAccessKey;
         internal readonly string _keyName;
         internal readonly TimeSpan _tokenTimeToLive;
-        private static readonly TimeSpan DefaultTokenTimeout = TimeSpan.FromMinutes(20);
 
-        internal SharedAccessSignatureTokenProvider(string connectionString)
+        private static readonly TimeSpan DefaultTokenTimeout = TimeSpan.FromMinutes(20);
+        private static readonly TimeSpan DefaultTokenRefreshTimeMargin = TimeSpan.FromMinutes(2);
+
+        internal SharedAccessSignatureTokenProvider(string connectionString):
+            base(DefaultTokenTimeout - DefaultTokenRefreshTimeMargin)
         {
             var builder = new NotificationHubConnectionStringBuilder(connectionString);
             this._keyName = builder.SharedAccessKeyName;
@@ -31,10 +34,10 @@ namespace Microsoft.Azure.NotificationHubs.Auth
         internal SharedAccessSignatureTokenProvider(string keyName, string sharedAccessKey)
             : this(keyName, sharedAccessKey, DefaultTokenTimeout)
         {
-            
         }
 
         internal SharedAccessSignatureTokenProvider(string keyName, string sharedAccessKey, TimeSpan tokenTimeToLive)
+            : base(tokenTimeToLive - DefaultTokenRefreshTimeMargin)
         {
             if (string.IsNullOrEmpty(keyName))
             {

--- a/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
+++ b/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
@@ -5,9 +5,9 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>2.0.1.0</VersionPrefix>
+    <VersionPrefix>2.0.2.0</VersionPrefix>
     <PackageId>Microsoft.Azure.NotificationHubs</PackageId>
-    <PackageVersion>2.0.1</PackageVersion>
+    <PackageVersion>2.0.2</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=218949</PackageLicenseUrl>
     <PackageProjectUrl>https://aka.ms/NHNuget</PackageProjectUrl>
@@ -20,7 +20,9 @@
 
       For more information on Notification Hub, please visit: http://azure.microsoft.com/en-us/documentation/articles/notification-hubs-overview/
     </Description>
-    <PackageReleaseNotes>Version 2.0.1 of the SDK, that supports .NET Standard 2.0</PackageReleaseNotes>
+    <PackageReleaseNotes>
+      Visit https://github.com/Azure/azure-notificationhubs-dotnet/releases for latest release notes.
+    </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft Azure windowsazureofficial NotificationHub Notifications Notification Hub Push Windows Phone iOS Android Baidu Kindle Amazon</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
The `SharedAccessSignatureTokenProvider` creates SAS tokens with 20-minute expiration time by default. To avoid re-creating tokens with each request, it uses memory cache with 1-minute expiration time. However, the memory cache uses sliding expiration window, so if the token is accessed every minute (or more frequently), the token is never removed from the cache and after 20 minutes it is rejected by the backend.

The fix contains two changes:
1. The in-memory cache uses absolute expiration time instead of sliding expiration window.
2. The in-memory cache expiration time is set to SAS token expiration time minus 2 minutes. That should give us enough time to refresh the token and have some safety margin for potential clock skew in the cloud.

Closes bugs #9 and #12