### PR TITLE
Add FCM support (#20)

### DIFF
--- a/Samples/CreateHubSample/CreateHubSample.csproj
+++ b/Samples/CreateHubSample/CreateHubSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />

--- a/Samples/ParseFeedbackSample/ParseFeedbackSample.csproj
+++ b/Samples/ParseFeedbackSample/ParseFeedbackSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />

--- a/Samples/ParseFeedbackSample/Program.cs
+++ b/Samples/ParseFeedbackSample/Program.cs
@@ -16,7 +16,7 @@ namespace ParseFeedbackSample
     class Program
     {
 
-        private const string GcmSampleNotificationContent = "{\"data\":{\"message\":\"Notification Hub test notification from SDK sample\"}}";
+        private const string FcmSampleNotificationContent = "{\"data\":{\"message\":\"Notification Hub test notification from SDK sample\"}}";
 
         static async Task Main(string[] args)
         {
@@ -25,41 +25,41 @@ namespace ParseFeedbackSample
             var nhClient = NotificationHubClient.CreateClientFromConnectionString(config.PrimaryConnectionString, config.HubName);
 
             // Register some fake devices
-            var gcmDeviceId1 = Guid.NewGuid().ToString();
-            var gcmInstallation1 = new Installation
+            var fcmDeviceId1 = Guid.NewGuid().ToString();
+            var fcmInstallation1 = new Installation
             {
-                InstallationId = "fake-gcm-install-id1",
-                Platform = NotificationPlatform.Gcm,
-                PushChannel = gcmDeviceId1,
+                InstallationId = "fake-fcm-install-id1",
+                Platform = NotificationPlatform.Fcm,
+                PushChannel = fcmDeviceId1,
                 PushChannelExpired = false,
-                Tags = new [] { "gcm" }
+                Tags = new [] { "fcm" }
             };
-            var gcmDeviceId2 = Guid.NewGuid().ToString();
-            var gcmInstallation2 = new Installation
+            var fcmDeviceId2 = Guid.NewGuid().ToString();
+            var fcmInstallation2= new Installation
             {
-                InstallationId = "fake-gcm-install-id2",
-                Platform = NotificationPlatform.Gcm,
-                PushChannel = gcmDeviceId2,
+                InstallationId = "fake-fcm-install-id2",
+                Platform = NotificationPlatform.Fcm,
+                PushChannel = fcmDeviceId2,
                 PushChannelExpired = false,
-                Tags = new[] { "gcm" }
+                Tags = new[] { "fcm" }
             };
-            await nhClient.CreateOrUpdateInstallationAsync(gcmInstallation1);
-            await nhClient.CreateOrUpdateInstallationAsync(gcmInstallation2);
+            await nhClient.CreateOrUpdateInstallationAsync(fcmInstallation1);
+            await nhClient.CreateOrUpdateInstallationAsync(fcmInstallation2);
 
             await Task.Delay(5000);
 
             // Send notifications to all users
-            var outcomeGcm = await nhClient.SendGcmNativeNotificationAsync(GcmSampleNotificationContent);
+            var outcomeFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent);
             
             // Gather send outcome
-            var gcmOutcomeDetails = await WaitForThePushStatusAsync("GCM", nhClient, outcomeGcm);
+            var fcmOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeFcm);
 
-            Console.WriteLine($"GCM error details URL: {gcmOutcomeDetails.PnsErrorDetailsUri}");
+            Console.WriteLine($"FCM error details URL: {fcmOutcomeDetails.PnsErrorDetailsUri}");
 
-            if (gcmOutcomeDetails.PnsErrorDetailsUri != null)
+            if (fcmOutcomeDetails.PnsErrorDetailsUri != null)
             {
                 var httpClient = new HttpClient();
-                var pnsFeedbackXmlStrings = await httpClient.GetStringAsync(gcmOutcomeDetails.PnsErrorDetailsUri);
+                var pnsFeedbackXmlStrings = await httpClient.GetStringAsync(fcmOutcomeDetails.PnsErrorDetailsUri);
 
                 // Parse XML
                 var pnsFeedbackXmlStringsSplit = pnsFeedbackXmlStrings.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -67,7 +67,7 @@ namespace ParseFeedbackSample
                 {
                     var xdoc = XDocument.Parse(pnsFeedbackXmlString);
                     XNamespace ns = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
-                    Console.WriteLine($"GCM PNS Feedback Content: \n{xdoc}");
+                    Console.WriteLine($"FCM PNS Feedback Content: \n{xdoc}");
                     PnsFeedback feedback = new PnsFeedback
                     {
                         FeedbackTime = DateTime.Parse(xdoc.Root.Element(ns + "FeedbackTime").Value),

--- a/Samples/RegistrationSample/Program.cs
+++ b/Samples/RegistrationSample/Program.cs
@@ -26,45 +26,45 @@ namespace RegistrationSample
         private static async Task CreateAndDeleteRegistrationAsync(NotificationHubClient nhClient)
         {
             var registrationId = await nhClient.CreateRegistrationIdAsync();
-            var registrationDescr = await nhClient.CreateGcmNativeRegistrationAsync(registrationId);
-            Console.WriteLine($"Created GCM registration {registrationDescr.GcmRegistrationId}");
+            var registrationDescr = await nhClient.CreateFcmNativeRegistrationAsync(registrationId);
+            Console.WriteLine($"Created FCM registration {registrationDescr.FcmRegistrationId}");
 
             var allRegistrations = await nhClient.GetAllRegistrationsAsync(1000);
             foreach (var regFromServer in allRegistrations)
             {
                 if (regFromServer.RegistrationId == registrationDescr.RegistrationId)
                 {
-                    Console.WriteLine($"Found GCM registration {registrationDescr.GcmRegistrationId}");
+                    Console.WriteLine($"Found FCM registration {registrationDescr.FcmRegistrationId}");
                     break;
                 }
             }
 
-            //registrationDescr = await nhClient.GetRegistrationAsync<GcmRegistrationDescription>(registrationId);
-            //Console.WriteLine($"Retrieved GCM registration {registrationDescr.GcmRegistrationId}");
+            //registrationDescr = await nhClient.GetRegistrationAsync<FcmRegistrationDescription>(registrationId);
+            //Console.WriteLine($"Retrieved FCM registration {registrationDescr.FcmRegistrationId}");
 
             await nhClient.DeleteRegistrationAsync(registrationDescr);
-            Console.WriteLine($"Deleted GCM registration {registrationDescr.GcmRegistrationId}");
+            Console.WriteLine($"Deleted FCM registration {registrationDescr.FcmRegistrationId}");
         }
 
         private static async Task CreateAndDeleteInstallationAsync(NotificationHubClient nhClient)
         {
             // Register some fake devices
-            var gcmDeviceId = Guid.NewGuid().ToString();
-            var gcmInstallation = new Installation
+            var fcmDeviceId = Guid.NewGuid().ToString();
+            var fcmInstallation = new Installation
             {
-                InstallationId = gcmDeviceId,
-                Platform = NotificationPlatform.Gcm,
-                PushChannel = gcmDeviceId,
+                InstallationId = fcmDeviceId,
+                Platform = NotificationPlatform.Fcm,
+                PushChannel = fcmDeviceId,
                 PushChannelExpired = false,
-                Tags = new[] { "gcm" }
+                Tags = new[] { "fcm" }
             };
-            await nhClient.CreateOrUpdateInstallationAsync(gcmInstallation);
+            await nhClient.CreateOrUpdateInstallationAsync(fcmInstallation);
 
             while (true)
             {
                 try
                 {
-                    var installationFromServer = await nhClient.GetInstallationAsync(gcmInstallation.InstallationId);
+                    var installationFromServer = await nhClient.GetInstallationAsync(fcmInstallation.InstallationId);
                     break;
                 }
                 catch (MessagingEntityNotFoundException)
@@ -73,18 +73,18 @@ namespace RegistrationSample
                     await Task.Delay(1000);
                 }
             }
-            Console.WriteLine($"Created GCM installation {gcmInstallation.InstallationId}");
-            await nhClient.DeleteInstallationAsync(gcmInstallation.InstallationId);
+            Console.WriteLine($"Created FCM installation {fcmInstallation.InstallationId}");
+            await nhClient.DeleteInstallationAsync(fcmInstallation.InstallationId);
             while (true)
             {
                 try
                 {
-                    var installationFromServer = await nhClient.GetInstallationAsync(gcmInstallation.InstallationId);
+                    var installationFromServer = await nhClient.GetInstallationAsync(fcmInstallation.InstallationId);
                     await Task.Delay(1000);
                 }
                 catch (MessagingEntityNotFoundException)
                 {
-                    Console.WriteLine($"Deleted GCM installation {gcmInstallation.InstallationId}");
+                    Console.WriteLine($"Deleted FCM installation {fcmInstallation.InstallationId}");
                     break;
                 }
             }

--- a/Samples/RegistrationSample/RegistrationSample.csproj
+++ b/Samples/RegistrationSample/RegistrationSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />

--- a/Samples/SendPushSample/Program.cs
+++ b/Samples/SendPushSample/Program.cs
@@ -14,8 +14,8 @@ namespace SendPushSample
 {
     class Program
     {
-        private const string GcmSampleNotificationContent = "{\"data\":{\"message\":\"Notification Hub test notification from SDK sample\"}}";
-        private const string GcmSampleSilentNotificationContent = "{ \"message\":{\"data\":{ \"Nick\": \"Mario\", \"body\": \"great match!\", \"Room\": \"PortugalVSDenmark\" } }}";
+        private const string FcmSampleNotificationContent = "{\"data\":{\"message\":\"Notification Hub test notification from SDK sample\"}}";
+        private const string FcmSampleSilentNotificationContent = "{ \"message\":{\"data\":{ \"Nick\": \"Mario\", \"body\": \"great match!\", \"Room\": \"PortugalVSDenmark\" } }}";
         private const string AppleSampleNotificationContent = "{\"aps\":{\"alert\":\"Notification Hub test notification from SDK sample\"}}";
         private const string AppleSampleSilentNotificationContent = "{\"aps\":{\"content-available\":1}, \"foo\": 2 }";
         private const string WnsSampleNotification = "<?xml version=\"1.0\" encoding=\"utf-8\"?><toast><visual><binding template=\"ToastText01\"><text id=\"1\">Notification Hub test notification from SDK sample</text></binding></visual></toast>";
@@ -27,16 +27,16 @@ namespace SendPushSample
             var nhClient = NotificationHubClient.CreateClientFromConnectionString(config.PrimaryConnectionString, config.HubName);
 
             // Register some fake devices
-            var gcmDeviceId = Guid.NewGuid().ToString();
-            var gcmInstallation = new Installation
+            var fcmDeviceId = Guid.NewGuid().ToString();
+            var fcmInstallation = new Installation
             {
-                InstallationId = "fake-gcm-install-id",
-                Platform = NotificationPlatform.Gcm,
-                PushChannel = gcmDeviceId,
+                InstallationId = "fake-fcm-install-id",
+                Platform = NotificationPlatform.Fcm,
+                PushChannel = fcmDeviceId,
                 PushChannelExpired = false,
-                Tags = new [] { "gcm" }
+                Tags = new [] { "fcm" }
             };
-            await nhClient.CreateOrUpdateInstallationAsync(gcmInstallation);
+            await nhClient.CreateOrUpdateInstallationAsync(fcmInstallation);
             
             var appleDeviceId = "00fc13adff785122b4ad28809a3420982341241421348097878e577c991de8f0";
             var apnsInstallation = new Installation
@@ -53,42 +53,42 @@ namespace SendPushSample
             {
                 case SampleConfiguration.Operation.Broadcast:
                     // Send notifications to all users
-                    var outcomeGcm = await nhClient.SendGcmNativeNotificationAsync(GcmSampleNotificationContent);
-                    var outcomeSilentGcm = await nhClient.SendGcmNativeNotificationAsync(GcmSampleSilentNotificationContent);
+                    var outcomeFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent);
+                    var outcomeSilentFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleSilentNotificationContent);
                     var outcomeApns = await nhClient.SendAppleNativeNotificationAsync(AppleSampleNotificationContent);
                     var outcomeSilentApns = await nhClient.SendAppleNativeNotificationAsync(AppleSampleSilentNotificationContent);
                     var outcomeWns = await nhClient.SendWindowsNativeNotificationAsync(WnsSampleNotification);
 
                     // Gather send outcome
-                    var gcmOutcomeDetails = await WaitForThePushStatusAsync("GCM", nhClient, outcomeGcm);
-                    var gcmSilentOutcomeDetails = await WaitForThePushStatusAsync("GCM", nhClient, outcomeSilentGcm);
+                    var fcmOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeFcm);
+                    var fcmSilentOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeSilentFcm);
                     var apnsOutcomeDetails = await WaitForThePushStatusAsync("APNS", nhClient, outcomeApns);
                     var apnsSilentOutcomeDetails = await WaitForThePushStatusAsync("APNS", nhClient, outcomeSilentApns);
                     var wnsOutcomeDetails = await WaitForThePushStatusAsync("WNS", nhClient, outcomeWns);
-                    PrintPushOutcome("GCM", gcmOutcomeDetails, gcmOutcomeDetails.GcmOutcomeCounts);
-                    PrintPushOutcome("GCM Silent ", gcmSilentOutcomeDetails, gcmSilentOutcomeDetails.GcmOutcomeCounts);
+                    PrintPushOutcome("FCM", fcmOutcomeDetails, fcmOutcomeDetails.FcmOutcomeCounts);
+                    PrintPushOutcome("FCM Silent ", fcmSilentOutcomeDetails, fcmSilentOutcomeDetails.FcmOutcomeCounts);
                     PrintPushOutcome("APNS", apnsOutcomeDetails, apnsOutcomeDetails.ApnsOutcomeCounts);
                     PrintPushOutcome("APNS Silent", apnsSilentOutcomeDetails, apnsSilentOutcomeDetails.ApnsOutcomeCounts);
                     PrintPushOutcome("WNS", wnsOutcomeDetails, wnsOutcomeDetails.WnsOutcomeCounts);
                     break;
                 case SampleConfiguration.Operation.SendByTag:
                     // Send notifications by tag
-                    var outcomeGcmByTag = await nhClient.SendGcmNativeNotificationAsync(GcmSampleNotificationContent, config.Tag ?? "gcm");
+                    var outcomeFcmByTag = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent, config.Tag ?? "fcm");
                     var outcomeApnsByTag = await nhClient.SendAppleNativeNotificationAsync(AppleSampleNotificationContent, config.Tag ?? "apns");
                     // Gather send outcome
-                    var gcmTagOutcomeDetails = await WaitForThePushStatusAsync("GCM Tags", nhClient, outcomeGcmByTag);
+                    var fcmTagOutcomeDetails = await WaitForThePushStatusAsync("FCM Tags", nhClient, outcomeFcmByTag);
                     var apnsTagOutcomeDetails = await WaitForThePushStatusAsync("APNS Tags", nhClient, outcomeApnsByTag);
-                    PrintPushOutcome("GCM Tags", gcmTagOutcomeDetails, gcmTagOutcomeDetails.GcmOutcomeCounts);
+                    PrintPushOutcome("FCM Tags", fcmTagOutcomeDetails, fcmTagOutcomeDetails.FcmOutcomeCounts);
                     PrintPushOutcome("APNS Tags", apnsTagOutcomeDetails, apnsTagOutcomeDetails.ApnsOutcomeCounts);
                     break;
                 case SampleConfiguration.Operation.SendByDevice:
                     // Send notifications by deviceId
-                    var outcomeGcmByDeviceId = await nhClient.SendDirectNotificationAsync(CreateGcmNotification(), config.GcmDeviceId ?? gcmDeviceId);
+                    var outcomeFcmByDeviceId = await nhClient.SendDirectNotificationAsync(CreateFcmNotification(), config.FcmDeviceId ?? fcmDeviceId);
                     var outcomeApnsByDeviceId = await nhClient.SendDirectNotificationAsync(CreateApnsNotification(), config.AppleDeviceId ?? appleDeviceId);
                     // Gather send outcome
-                    var gcmDirectSendOutcomeDetails = await WaitForThePushStatusAsync("GCM direct", nhClient, outcomeGcmByDeviceId);
+                    var fcmDirectSendOutcomeDetails = await WaitForThePushStatusAsync("FCM direct", nhClient, outcomeFcmByDeviceId);
                     var apnsDirectSendOutcomeDetails = await WaitForThePushStatusAsync("APNS direct", nhClient, outcomeApnsByDeviceId);
-                    PrintPushOutcome("GCM Direct", gcmDirectSendOutcomeDetails, gcmDirectSendOutcomeDetails.ApnsOutcomeCounts);
+                    PrintPushOutcome("FCM Direct", fcmDirectSendOutcomeDetails, fcmDirectSendOutcomeDetails.ApnsOutcomeCounts);
                     PrintPushOutcome("APNS Direct", apnsDirectSendOutcomeDetails, apnsDirectSendOutcomeDetails.ApnsOutcomeCounts);
                     break;
                 default:
@@ -97,9 +97,9 @@ namespace SendPushSample
             }
         }
 
-        private static Notification CreateGcmNotification()
+        private static Notification CreateFcmNotification()
         {
-            return new GcmNotification(GcmSampleNotificationContent);
+            return new FcmNotification(FcmSampleNotificationContent);
         }
 
         private static Notification CreateApnsNotification()

--- a/Samples/SendPushSample/SampleConfiguration.cs
+++ b/Samples/SendPushSample/SampleConfiguration.cs
@@ -11,7 +11,7 @@ namespace SendPushSample
         public string PrimaryConnectionString { get; set; }
         public string HubName { get; set; }
         public string Tag {get; set; }
-        public string GcmDeviceId {get; set; }
+        public string FcmDeviceId {get; set; }
         public string AppleDeviceId {get; set; }
         public string SendType {get; set; }
 

--- a/Samples/SendPushSample/SendPushSample.csproj
+++ b/Samples/SendPushSample/SendPushSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             LoadMockData();
             await DeleteAllRegistrationsAndInstallations();
 
-            var registration = new GcmRegistrationDescription(_configuration["GcmDeviceToken"]);
+            var registration = new FcmRegistrationDescription(_configuration["GcmDeviceToken"]);
             registration.PushVariables = new Dictionary<string, string>()
             {
                 {"var1", "value1"}
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             Assert.NotNull(createdRegistration.ExpirationTime);
             Assert.Contains(new KeyValuePair<string, string>("var1", "value1"), createdRegistration.PushVariables);
             Assert.Contains("tag1", createdRegistration.Tags);
-            Assert.Equal(registration.GcmRegistrationId, createdRegistration.GcmRegistrationId);
+            Assert.Equal(registration.FcmRegistrationId, createdRegistration.FcmRegistrationId);
             RecordTestResults();
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             LoadMockData();
             await DeleteAllRegistrationsAndInstallations();
 
-            var registration = new GcmTemplateRegistrationDescription(_configuration["GcmDeviceToken"], "{\"data\":{\"message\":\"Message\"}}");
+            var registration = new FcmTemplateRegistrationDescription(_configuration["GcmDeviceToken"], "{\"data\":{\"message\":\"Message\"}}");
             registration.PushVariables = new Dictionary<string, string>()
             {
                 {"var1", "value1"}
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             Assert.NotNull(createdRegistration.ExpirationTime);
             Assert.Contains(new KeyValuePair<string, string>("var1", "value1"), createdRegistration.PushVariables);
             Assert.Contains("tag1", createdRegistration.Tags);
-            Assert.Equal(registration.GcmRegistrationId, createdRegistration.GcmRegistrationId);
+            Assert.Equal(registration.FcmRegistrationId, createdRegistration.FcmRegistrationId);
             Assert.Equal(registration.BodyTemplate.Value, createdRegistration.BodyTemplate.Value);
             Assert.Equal(registration.TemplateName, createdRegistration.TemplateName);
             RecordTestResults();
@@ -423,17 +423,17 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             await DeleteAllRegistrationsAndInstallations();
 
             var appleRegistration = new AppleRegistrationDescription(_configuration["AppleDeviceToken"]);
-            var gcmRegistration = new GcmRegistrationDescription(_configuration["GcmDeviceToken"]);
+            var fcmRegistration = new FcmRegistrationDescription(_configuration["GcmDeviceToken"]);
 
             var createdAppleRegistration = await _hubClient.CreateRegistrationAsync(appleRegistration);
-            var createdGcmRegistration = await _hubClient.CreateRegistrationAsync(gcmRegistration);
+            var createdFcmRegistration = await _hubClient.CreateRegistrationAsync(fcmRegistration);
 
             var allRegistrations = await _hubClient.GetAllRegistrationsAsync(100);
             var allRegistrationIds = allRegistrations.Select(r => r.RegistrationId).ToArray();
 
             Assert.Equal(2, allRegistrationIds.Count());
             Assert.Contains(createdAppleRegistration.RegistrationId, allRegistrationIds);
-            Assert.Contains(createdGcmRegistration.RegistrationId, allRegistrationIds);
+            Assert.Contains(createdFcmRegistration.RegistrationId, allRegistrationIds);
             RecordTestResults();
         }
 
@@ -476,12 +476,12 @@ namespace Microsoft.Azure.NotificationHubs.Tests
 
             var appleRegistration1 = new AppleRegistrationDescription(_configuration["AppleDeviceToken"]);
             var appleRegistration2 = new AppleRegistrationDescription(_configuration["AppleDeviceToken"]);
-            var gcmRegistration = new GcmRegistrationDescription(_configuration["GcmDeviceToken"]);
+            var fcmRegistration = new FcmRegistrationDescription(_configuration["GcmDeviceToken"]);
 
             var createdAppleRegistration1 = await _hubClient.CreateRegistrationAsync(appleRegistration1);
             var createdAppleRegistration2 = await _hubClient.CreateRegistrationAsync(appleRegistration2);
             // Create a registration with another channel to make sure that SDK passes correct channel and two registrations will be returned
-            var createdGcmRegistration = await _hubClient.CreateRegistrationAsync(gcmRegistration);
+            var createdFcmRegistration = await _hubClient.CreateRegistrationAsync(fcmRegistration);
 
             var allRegistrations = await _hubClient.GetRegistrationsByChannelAsync(_configuration["AppleDeviceToken"], 100);
             var allRegistrationIds = allRegistrations.Select(r => r.RegistrationId).ToArray();
@@ -500,12 +500,12 @@ namespace Microsoft.Azure.NotificationHubs.Tests
 
             var appleRegistration1 = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new []{ "tag1" });
             var appleRegistration2 = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new[] { "tag1" });
-            var gcmRegistration = new GcmRegistrationDescription(_configuration["GcmDeviceToken"]);
+            var fcmRegistration = new FcmRegistrationDescription(_configuration["GcmDeviceToken"]);
 
             var createdAppleRegistration1 = await _hubClient.CreateRegistrationAsync(appleRegistration1);
             var createdAppleRegistration2 = await _hubClient.CreateRegistrationAsync(appleRegistration2);
             // Create a registration with another channel to make sure that SDK passes correct tag and two registrations will be returned
-            var createdGcmRegistration = await _hubClient.CreateRegistrationAsync(gcmRegistration);
+            var createdFcmRegistration = await _hubClient.CreateRegistrationAsync(fcmRegistration);
 
             var allRegistrations = await _hubClient.GetRegistrationsByTagAsync("tag1", 100);
             var allRegistrationIds = allRegistrations.Select(r => r.RegistrationId).ToArray();
@@ -813,7 +813,7 @@ namespace Microsoft.Azure.NotificationHubs.Tests
         private async Task SendNotificationAsync_SendGcmNativeNotification_GetSuccessfulResultBack()
         {
             LoadMockData();
-            var notification = new GcmNotification("{\"data\":{\"message\":\"Message\"}}");
+            var notification = new FcmNotification("{\"data\":{\"message\":\"Message\"}}");
 
             var notificationResult = await _hubClient.SendNotificationAsync(notification, "someRandomTag1 && someRandomTag2");
 

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/appsettings.json
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/appsettings.json
@@ -6,6 +6,7 @@
   "BaiduUserId": "userId",
   "BaiduChannelId": "channelId",
   "GcmDeviceToken": "amzn1.adm-registration.v2.123",
+  "FcmDeviceToken": "amzn1.adm-registration.v2.123",
   "MpnsDeviceToken": "https://some.url",
   "WindowsDeviceToken": "https://some.url",
   "BlobContainer": "<insert value here before running tests>"

--- a/src/Microsoft.Azure.NotificationHubs/AndroidRegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/AndroidRegistrationDescription.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.NotificationHubs
     /// Represents Notification Hub registration description for Google Cloud Messaging
     /// </summary>
     [DataContract(Name = ManagementStrings.GcmRegistrationDescription, Namespace = ManagementStrings.Namespace)]
-    public class GcmRegistrationDescription : RegistrationDescription
+    [Obsolete("GcmRegistrationDescription is deprecated, please use FcmRegistrationDescription instead.")]
+    internal class GcmRegistrationDescription : RegistrationDescription
     {
         /// <summary>
         /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.GcmRegistrationDescription"/> class by copying fields from the given instance
@@ -44,6 +45,16 @@ namespace Microsoft.Azure.NotificationHubs
         public GcmRegistrationDescription(string gcmRegistrationId, IEnumerable<string> tags)
             : this(string.Empty, gcmRegistrationId, tags)
         {
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="T:Microsoft.Azure.NotificationHubs.GcmRegistrationDescription"/> class from <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> object.
+        /// </summary>
+        /// <param name="fcmRegistration">FcmRegistrationDescription object to create GcmRegistrationDescription from.</param>
+        public GcmRegistrationDescription(FcmRegistrationDescription fcmRegistration)
+            : base(fcmRegistration)
+        {
+            this.GcmRegistrationId = fcmRegistration.FcmRegistrationId;
         }
 
         internal GcmRegistrationDescription(string notificationHubPath, string gcmRegistrationId, IEnumerable<string> tags)
@@ -103,6 +114,114 @@ namespace Microsoft.Azure.NotificationHubs
         internal override RegistrationDescription Clone()
         {
             return new GcmRegistrationDescription(this);
+        }
+    }
+
+    /// <summary>
+    /// Represents Notification Hub registration description for Firebase Cloud Messaging
+    /// </summary>
+    [DataContract(Name = ManagementStrings.FcmRegistrationDescription, Namespace = ManagementStrings.Namespace)]
+    public class FcmRegistrationDescription : RegistrationDescription
+    {
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> class by copying fields from the given instance
+        /// </summary>
+        /// <param name="sourceRegistration">Another <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> instance fields values are copyed from</param>
+        public FcmRegistrationDescription(FcmRegistrationDescription sourceRegistration)
+            : base(sourceRegistration)
+        {
+            this.FcmRegistrationId = sourceRegistration.FcmRegistrationId;
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> class using given Firebase Cloud Messaging registration id
+        /// </summary>
+        /// <param name="fcmRegistrationId">Registration id obtained from the Firebase Cloud Messaging service</param>
+        public FcmRegistrationDescription(string fcmRegistrationId)
+            : this(string.Empty, fcmRegistrationId, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> class using given Firebase Cloud Messaging registration id and collection of tags
+        /// </summary>
+        /// <param name="fcmRegistrationId">Registration id obtained from the Firebase Cloud Messaging service</param>
+        /// <param name="tags">Collection of tags. Tags can be used for audience targeting purposes.</param>
+        public FcmRegistrationDescription(string fcmRegistrationId, IEnumerable<string> tags)
+            : this(string.Empty, fcmRegistrationId, tags)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmRegistrationDescription"/> class from <see cref="T:Microsoft.Azure.NotificationHubs.GcmRegistrationDescription"/> object.
+        /// </summary>
+        /// <param name="gcmRegistration">GcmRegistrationDescription object to create new FcmRegistrationDescription from.</param>
+        internal FcmRegistrationDescription(GcmRegistrationDescription gcmRegistration)
+            : base(gcmRegistration)
+        {
+            this.FcmRegistrationId = gcmRegistration.GcmRegistrationId;
+            this.ExpirationTime = gcmRegistration.ExpirationTime;
+            this.ExtensionData = gcmRegistration.ExtensionData;
+            this.PushVariables = gcmRegistration.PushVariables;
+        }
+
+        internal FcmRegistrationDescription(string notificationHubPath, string fcmRegistrationId, IEnumerable<string> tags)
+            : base(notificationHubPath)
+        {
+            if (string.IsNullOrWhiteSpace(fcmRegistrationId))
+            {
+                throw new ArgumentNullException("fcmRegistrationId");
+            }
+
+            this.FcmRegistrationId = fcmRegistrationId;
+            if (tags != null)
+            {
+                this.Tags = new HashSet<string>(tags);
+            }
+        }
+
+        /// <summary>
+        /// Registration id obtained from the Firebase Messaging service
+        /// </summary>
+        [DataMember(Name = ManagementStrings.FcmRegistrationId, Order = 2001, IsRequired = true)]
+        public string FcmRegistrationId { get; set; }
+
+        internal override string AppPlatForm
+        {
+            get { return FcmCredential.AppPlatformName; }
+        }
+
+        internal override string RegistrationType
+        {
+            get { return FcmCredential.AppPlatformName; }
+        }
+
+        internal override string PlatformType
+        {
+            get { return FcmCredential.AppPlatformName; }
+        }
+
+        internal override string GetPnsHandle()
+        {
+            return this.FcmRegistrationId;
+        }
+
+        internal override void SetPnsHandle(string pnsHandle)
+        {
+            this.FcmRegistrationId = pnsHandle;
+        }
+
+        internal override void OnValidate(ApiVersion version)
+        {
+            if (string.IsNullOrWhiteSpace(this.FcmRegistrationId))
+            {
+                throw new InvalidDataContractException(SRClient.FCMRegistrationInvalidId);
+            }
+        }
+
+        internal override RegistrationDescription Clone()
+        {
+            return new FcmRegistrationDescription(this);
         }
     }
 }

--- a/src/Microsoft.Azure.NotificationHubs/AndroidTemplateRegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/AndroidTemplateRegistrationDescription.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.NotificationHubs
     /// Represents Notification Hub template registration description for Google Cloud Messaging
     /// </summary>
     [DataContract(Name = ManagementStrings.GcmTemplateRegistrationDescription, Namespace = ManagementStrings.Namespace)]
-    public class GcmTemplateRegistrationDescription : GcmRegistrationDescription
+    [Obsolete("GcmTemplateRegistrationDescription is deprecated, please use FcmTemplateRegistrationDescription instead.")]
+    internal class GcmTemplateRegistrationDescription : GcmRegistrationDescription
     {
         internal override string AppPlatForm
         {
@@ -84,6 +85,17 @@ namespace Microsoft.Azure.NotificationHubs
         public GcmTemplateRegistrationDescription(string gcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
             : this(string.Empty, gcmRegistrationId, jsonPayload, tags)
         {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.GcmTemplateRegistrationDescription"/> class from <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> object.
+        /// </summary>
+        /// <param name="fcmTemplateRegistration">FcmTemplateRegistrationDescription object to create new GcmTemplateRegistrationDescription from.</param>
+        public GcmTemplateRegistrationDescription(FcmTemplateRegistrationDescription fcmTemplateRegistration)
+            : base(fcmTemplateRegistration)
+        {
+            this.BodyTemplate = fcmTemplateRegistration.BodyTemplate;
+            this.TemplateName = fcmTemplateRegistration.TemplateName;
         }
 
         internal GcmTemplateRegistrationDescription(string notificationHubPath, string gcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
@@ -157,6 +169,162 @@ namespace Microsoft.Azure.NotificationHubs
         internal override RegistrationDescription Clone()
         {
             return new GcmTemplateRegistrationDescription(this);
+        }
+    }
+
+     /// <summary>
+    /// Represents Notification Hub template registration description for Firebase Cloud Messaging
+    /// </summary>
+    [DataContract(Name = ManagementStrings.FcmTemplateRegistrationDescription, Namespace = ManagementStrings.Namespace)]
+    public class FcmTemplateRegistrationDescription : FcmRegistrationDescription
+    {
+        internal override string AppPlatForm
+        {
+            get
+            {
+                return FcmCredential.AppPlatformName;
+            }
+        }
+
+        internal override string RegistrationType
+        {
+            get
+            {
+                return RegistrationDescription.TemplateRegistrationType;
+            }
+        }
+
+        internal override string PlatformType
+        {
+            get
+            {
+                return FcmCredential.AppPlatformName + RegistrationDescription.TemplateRegistrationType;
+            }
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> class by copying fields from the given instance
+        /// </summary>
+        /// <param name="sourceRegistration">Another <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> instance fields values are copyed from</param>
+        public FcmTemplateRegistrationDescription(FcmTemplateRegistrationDescription sourceRegistration)
+            : base(sourceRegistration)
+        {
+            this.BodyTemplate = sourceRegistration.BodyTemplate;
+            this.TemplateName = sourceRegistration.TemplateName;
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> class using given Firebase Cloud Messaging registration id
+        /// </summary>
+        /// <param name="fcmRegistrationId">Registration id obtained from the Firebase Cloud Messaging service</param>
+        public FcmTemplateRegistrationDescription(string fcmRegistrationId)
+            : base(fcmRegistrationId)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> class using given Firebase Cloud Messaging registration id and template for payload
+        /// </summary>
+        /// <param name="fcmRegistrationId">Registration id obtained from the Firebase Cloud Messaging service</param>
+        /// <param name="jsonPayload">Payload template</param>
+        public FcmTemplateRegistrationDescription(string fcmRegistrationId, string jsonPayload)
+            : this(string.Empty, fcmRegistrationId, jsonPayload, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> class using given Firebase Cloud Messaging registration id, template for payload and collection of tags
+        /// </summary>
+        /// <param name="fcmRegistrationId">Registration id obtained from the Firebase Cloud Messaging service</param>
+        /// <param name="jsonPayload">Payload template</param>
+        /// <param name="tags">Collection of tags. Tags can be used for audience targeting purposes.</param>
+        public FcmTemplateRegistrationDescription(string fcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
+            : this(string.Empty, fcmRegistrationId, jsonPayload, tags)
+        {
+        }
+
+        /// <summary>
+        /// Creates instance of <see cref="T:Microsoft.Azure.NotificationHubs.FcmTemplateRegistrationDescription"/> class from  <see cref="T:Microsoft.Azure.NotificationHubs.GcmTemplateRegistrationDescription"/> object.
+        /// </summary>
+        /// <param name="gcmRegistration">The GcmTempalteRegistration object to create new FcmTemplateRegistraitonDescription from.</param>
+        internal FcmTemplateRegistrationDescription(GcmTemplateRegistrationDescription gcmRegistration)
+            : base(gcmRegistration)
+        {
+            this.BodyTemplate = gcmRegistration.BodyTemplate;
+            this.TemplateName = gcmRegistration.TemplateName;
+        }
+
+        internal FcmTemplateRegistrationDescription(string notificationHubPath, string fcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
+            : base(notificationHubPath, fcmRegistrationId, tags)
+        {
+            if (string.IsNullOrWhiteSpace(jsonPayload))
+            {
+                throw new ArgumentNullException("jsonPayload");
+            }
+
+            this.BodyTemplate = new CDataMember(jsonPayload);
+        }
+
+        /// <summary>
+        /// Gets or sets a template body for notification payload which may contain placeholders to be filled in with actual data during the send operation
+        /// </summary>
+        [DataMember(Name = ManagementStrings.BodyTemplate, IsRequired = true, Order = 3001)]
+        public CDataMember BodyTemplate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a name of the template
+        /// </summary>
+        [DataMember(Name = ManagementStrings.TemplateName, IsRequired = false, Order = 3002)]
+        public string TemplateName { get; set; }
+
+        internal override void OnValidate(ApiVersion version)
+        {
+            base.OnValidate(version);
+
+            try
+            {
+                using (XmlReader reader = JsonReaderWriterFactory.CreateJsonReader(Encoding.UTF8.GetBytes(this.BodyTemplate), new XmlDictionaryReaderQuotas()))
+                {
+                    XDocument payloadDocument = XDocument.Load(reader);
+
+                    foreach (XElement element in payloadDocument.Root.DescendantsAndSelf())
+                    {
+                        foreach (XAttribute attribute in element.Attributes())
+                        {
+                            ExpressionEvaluator.Validate(attribute.Value, version);
+                        }
+
+                        if (!element.HasElements && !string.IsNullOrEmpty(element.Value))
+                        {
+                            ExpressionEvaluator.Validate(element.Value, version);
+                        }
+                    }
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // We get an ugly and misleading error message when this exception happens -> The XmlReader state should be Interactive.
+                // Hence we are using a more friendlier error message
+                throw new XmlException(SRClient.FailedToDeserializeBodyTemplate);
+            }
+
+            this.ValidateTemplateName();
+        }
+
+        private void ValidateTemplateName()
+        {
+            if (this.TemplateName != null)
+            {
+                if (this.TemplateName.Length > RegistrationSDKHelper.TemplateMaxLength)
+                {
+                    throw new InvalidDataContractException(SRClient.TemplateNameLengthExceedsLimit(RegistrationSDKHelper.TemplateMaxLength));
+                }
+            }
+        }
+
+        internal override RegistrationDescription Clone()
+        {
+            return new FcmTemplateRegistrationDescription(this);
         }
     }
 }

--- a/src/Microsoft.Azure.NotificationHubs/FCMNotification.cs
+++ b/src/Microsoft.Azure.NotificationHubs/FCMNotification.cs
@@ -9,16 +9,15 @@ namespace Microsoft.Azure.NotificationHubs
     using System;
 
     /// <summary>
-    /// Represents a Google Cloud Messaging notification.
+    /// Represents a Firebase Cloud Messaging notification.
     /// </summary>
-    [Obsolete("GcmNotification is deprecated, please use FcmNotification instead.")]
-    internal sealed class GcmNotification : Notification, INativeNotification
+    public sealed class FcmNotification : Notification, INativeNotification
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.GcmNotification"/> class.
+        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.FcmNotification"/> class.
         /// </summary>
         /// <param name="jsonPayload">The JSON payload.</param>
-        public GcmNotification(string jsonPayload)
+        public FcmNotification(string jsonPayload)
             : base(null, null)
         {
             if (string.IsNullOrWhiteSpace(jsonPayload))
@@ -30,11 +29,11 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.GcmNotification"/> class.
+        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.FcmNotification"/> class.
         /// </summary>
         /// <param name="jsonPayload">The JSON payload.</param><param name="tag">The notification tag.</param>
         [Obsolete("This method is obsolete.")]
-        public GcmNotification(string jsonPayload, string tag)
+        public FcmNotification(string jsonPayload, string tag)
             : base(null, tag)
         {
             if (string.IsNullOrWhiteSpace(jsonPayload))
@@ -46,17 +45,6 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.GcmNotification"/> class from <see cref="T:Microsoft.Azure.NotificationHubs.FcmNotification"/> object.
-        /// </summary>
-        /// <param name="fcmNotification">The FcmNotification object to create a new GcmNotifications from.</param>
-        [Obsolete("This method is obsolete.")]
-        public GcmNotification(FcmNotification fcmNotification)
-            : base(fcmNotification.Headers, fcmNotification.Tag)
-        {
-            this.Body = fcmNotification.Body;
-        }
-
-        /// <summary>
         /// Gets the type of the platform.
         /// </summary>
         /// <value>
@@ -64,7 +52,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </value>
         protected override string PlatformType
         {
-            get { return GcmCredential.AppPlatformName; }
+            get { return FcmCredential.AppPlatformName; }
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.NotificationHubs/FcmCredential.cs
+++ b/src/Microsoft.Azure.NotificationHubs/FcmCredential.cs
@@ -11,43 +11,41 @@ namespace Microsoft.Azure.NotificationHubs
     using System.Runtime.Serialization;
 
     /// <summary>
-    /// Represents the Google Cloud Messaging credential.
+    /// Represents the Firebase Cloud Messaging credential.
     /// </summary>
-    [DataContract(Name = ManagementStrings.GcmCredential, Namespace = ManagementStrings.Namespace)]
-    [Obsolete("GcmCredential is deprecated, please use FcmCredential instead.")]
-    
-    internal class GcmCredential : PnsCredential
+    [DataContract(Name = ManagementStrings.FcmCredential, Namespace = ManagementStrings.Namespace)]
+    public class FcmCredential : PnsCredential
     {
-        internal const string AppPlatformName = "gcm";
-        internal const string ProdAccessTokenServiceUrl = @"https://android.googleapis.com/gcm/send";
+        internal const string AppPlatformName = "fcm";
+        internal const string ProdAccessTokenServiceUrl = @"https://fcm.googleapis.com/fcm/send";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.GcmCredential"/> class.
+        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.FcmCredential"/> class.
         /// </summary>
-        public GcmCredential()
+        public FcmCredential()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.GcmCredential"/> class.
+        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.NotificationHubs.FcmCredential"/> class.
         /// </summary>
         /// <param name="googleApiKey">The Google API key.</param>
-        public GcmCredential(string googleApiKey)
+        public FcmCredential(string googleApiKey)
         {
             this.GoogleApiKey = googleApiKey;
         }
 
         /// <summary>
-        /// Gets or sets the GCM endpoint.
+        /// Gets or sets the FCM endpoint.
         /// </summary>
         /// 
         /// <returns>
-        /// The GCM endpoint.
+        /// The FCM endpoint.
         /// </returns>
-        public string GcmEndpoint
+        public string FcmEndpoint
         {
-            get { return base["GcmEndpoint"] ?? GcmCredential.ProdAccessTokenServiceUrl; }
-            set { base["GcmEndpoint"] = value; }
+            get { return base["FcmEndpoint"] ?? FcmCredential.ProdAccessTokenServiceUrl; }
+            set { base["FcmEndpoint"] = value; }
         }
 
         /// <summary>
@@ -65,7 +63,7 @@ namespace Microsoft.Azure.NotificationHubs
 
         internal override string AppPlatform
         {
-            get { return GcmCredential.AppPlatformName; }
+            get { return FcmCredential.AppPlatformName; }
         }
 
         /// <summary>
@@ -78,7 +76,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="other">The other object to compare.</param>
         public override bool Equals(object other)
         {
-            GcmCredential otherCredential = other as GcmCredential;
+            FcmCredential otherCredential = other as FcmCredential;
             if (otherCredential == null)
             {
                 return false;

--- a/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
@@ -44,8 +44,16 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
                 this.CreateSerializer<GcmRegistrationDescription>());
 
             this.entirySerializers.Add(
+                typeof(FcmRegistrationDescription).Name,
+                this.CreateSerializer<FcmRegistrationDescription>());
+
+            this.entirySerializers.Add(
                 typeof(GcmTemplateRegistrationDescription).Name,
                 this.CreateSerializer<GcmTemplateRegistrationDescription>());
+
+            this.entirySerializers.Add(
+                typeof(FcmTemplateRegistrationDescription).Name,
+                this.CreateSerializer<FcmTemplateRegistrationDescription>());
 
             this.entirySerializers.Add(
                 typeof(MpnsRegistrationDescription).Name,
@@ -141,6 +149,17 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
                 OmitXmlDeclaration = true
             };
 
+            // Convert FCM descriptions into their GCM counterparts
+            if (description.GetType().Name == "FcmRegistrationDescription")
+            {
+                description = new GcmRegistrationDescription((FcmRegistrationDescription) description);
+            }
+
+            if (description.GetType().Name == "FcmTemplateRegistrationDescription")
+            {
+                description = new GcmTemplateRegistrationDescription((FcmTemplateRegistrationDescription) description);
+            }
+
             var serializer = GetSerializer(description.GetType().Name);
             using (var xmlWriter = XmlWriter.Create(stringBuilder, settings))
             {
@@ -152,6 +171,17 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
 
         public void Serialize(EntityDescription description, XmlWriter writer)
         {
+            // Convert FCM descriptions into their GCM counterparts
+            if (description.GetType().Name == "FcmRegistrationDescription")
+            {
+                description = new GcmRegistrationDescription((FcmRegistrationDescription) description);
+            }
+
+            if (description.GetType().Name == "FcmTemplateRegistrationDescription")
+            {
+                description = new GcmTemplateRegistrationDescription((FcmTemplateRegistrationDescription) description);
+            }
+
             var serializer = GetSerializer(description.GetType().Name);
             serializer.WriteObject(writer, description);
         }

--- a/src/Microsoft.Azure.NotificationHubs/Messaging/ManagementStrings.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Messaging/ManagementStrings.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             public const string Name = "Name";
             public const string RegistrationCollection = "Registrations";
             public const string GcmRegistrationDescription = "GcmRegistrationDescription";
+            public const string FcmRegistrationDescription = "FcmRegistrationDescription";
             public const string GcmTemplateRegistrationDescription = "GcmTemplateRegistrationDescription";
+            public const string FcmTemplateRegistrationDescription = "FcmTemplateRegistrationDescription";
             public const string BaiduRegistrationDescription = "BaiduRegistrationDescription";
             public const string BaiduTemplateRegistrationDescription = "BaiduTemplateRegistrationDescription";
             public const string WindowsRegistrationDescription = "WindowsRegistrationDescription";
@@ -47,12 +49,14 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             public const string PnsCredential = "PnsCredential";
             public const string PnsCredentials = "PnsCredentials";
             public const string GcmCredential = "GcmCredential";
+            public const string FcmCredential = "FcmCredential";
             public const string BaiduCredential = "BaiduCredential";
             public const string WnsCredential = "WnsCredential";
             public const string ApnsCredential = "ApnsCredential";
             public const string AdmCredential = "AdmCredential";
             public const string EmailAddress = "EmailAddress";
             public const string GcmRegistrationId = "GcmRegistrationId";
+            public const string FcmRegistrationId = "FcmRegistrationId";
             public const string BaiduUserId = "BaiduUserId";
             public const string BaiduChannelId = "BaiduChannelId";
             public const string MpnsCredential = "MpnsCredential";
@@ -151,6 +155,7 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             public const string MpnsOutcomeCounts = "MpnsOutcomeCounts";
             public const string WnsOutcomeCounts = "WnsOutcomeCounts";
             public const string GcmOutcomeCounts = "GcmOutcomeCounts";
+            public const string FcmOutcomeCounts = "FcmOutcomeCounts";
             public const string AdmOutcomeCounts = "AdmOutcomeCounts";
             public const string BaiduOutcomeCounts = "BaiduOutcomeCounts";
             public const string NotificationBody = "NotificationBody";

--- a/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
+++ b/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
@@ -5,9 +5,9 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>2.0.2.0</VersionPrefix>
+    <VersionPrefix>3.0.0.0</VersionPrefix>
     <PackageId>Microsoft.Azure.NotificationHubs</PackageId>
-    <PackageVersion>2.0.2</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=218949</PackageLicenseUrl>
     <PackageProjectUrl>https://aka.ms/NHNuget</PackageProjectUrl>

--- a/src/Microsoft.Azure.NotificationHubs/NotificationDetails.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationDetails.cs
@@ -141,7 +141,28 @@ namespace Microsoft.Azure.NotificationHubs
         /// The notification GCM outcome counts.
         /// </value>
         [DataMember(Name = ManagementStrings.GcmOutcomeCounts, IsRequired = false, Order = 1013, EmitDefaultValue = false)]
-        public NotificationOutcomeCollection GcmOutcomeCounts { get; set; }
+        private NotificationOutcomeCollection GcmOutcomeCounts { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification FCM outcome counts.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// This field acts as proxy for GcmOutcomeCounts at the moment as FcmNotificaiton instances are converted to GcmNotification when
+        /// sent out to the Notification Hub, making it impossible to distinguish the two in the response as from the NH's perspective, the
+        /// GcmNotification was received. See <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationImplAsync"/> and
+        /// <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendScheduledNotificationImplAsync"/> methods for conversion details.
+        /// </remarks>
+        /// 
+        /// <value>
+        /// The notification FCM outcome counts.
+        /// </value>
+        [DataMember(Name = ManagementStrings.FcmOutcomeCounts, IsRequired = false, Order = 1016, EmitDefaultValue = false)]
+        public NotificationOutcomeCollection FcmOutcomeCounts
+        {
+            get { return GcmOutcomeCounts; }
+            set { GcmOutcomeCounts = value; }
+        }
 
         /// <summary>
         /// Gets or sets the notification ADM outcome counts.

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -4,6 +4,8 @@
 // license information.
 //----------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.Azure.NotificationHubs
 {
     using Auth;
@@ -23,6 +25,8 @@ namespace Microsoft.Azure.NotificationHubs
     using System.Threading.Tasks;
     using System.Web;
     using System.Xml;
+
+
 
     /// <summary>
     /// Represents a notification hub client.
@@ -360,7 +364,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
         /// </returns>
-        public Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload)
+        [Obsolete("SendGcmNativeNotificationAsync is deprecated, please use SendFcmNativeNotificationAsync instead.")]
+        internal Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload)
         {
             return SendGcmNativeNotificationAsync(jsonPayload, string.Empty);
         }
@@ -373,7 +378,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
         /// </returns>
-        public Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload, string tagExpression)
+        [Obsolete("SendGcmNativeNotificationAsync is deprecated, please use SendFcmNativeNotificationAsync instead.")]
+        internal Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload, string tagExpression)
         {
             return SendNotificationAsync(new GcmNotification(jsonPayload), tagExpression);
         }
@@ -386,9 +392,48 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
         /// </returns>
-        public Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags)
+        [Obsolete("SendGcmNativeNotificationAsync is deprecated, please use SendFcmNativeNotificationAsync instead.")]
+        internal Task<NotificationOutcome> SendGcmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags)
         {
             return SendNotificationAsync(new GcmNotification(jsonPayload), tags);
+        }
+
+        /// <summary>
+        /// Sends Firebase Cloud Messaging (FCM) native notification.
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload)
+        {
+            return SendFcmNativeNotificationAsync(jsonPayload, string.Empty);
+        }
+
+        /// <summary>
+        /// Sends FCM native notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, string tagExpression)
+        {
+            return SendNotificationAsync(new FcmNotification(jsonPayload), tagExpression);
+        }
+
+        /// <summary>
+        /// Sends a FCM native notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||").
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags)
+        {
+            return SendNotificationAsync(new FcmNotification(jsonPayload), tags);
         }
 
         /// <summary>
@@ -1028,7 +1073,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<GcmRegistrationDescription> CreateGcmNativeRegistrationAsync(string gcmRegistrationId)
+        [Obsolete("CreateGcmNativeRegistrationAsync is deprecated, please use CreateFcmNativeRegistrationAsync instead.")]
+        internal Task<GcmRegistrationDescription> CreateGcmNativeRegistrationAsync(string gcmRegistrationId)
         {
             return CreateGcmNativeRegistrationAsync(gcmRegistrationId, null);
         }
@@ -1041,7 +1087,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<GcmRegistrationDescription> CreateGcmNativeRegistrationAsync(string gcmRegistrationId, IEnumerable<string> tags)
+        [Obsolete("CreateGcmNativeRegistrationAsync is deprecated, please use CreateFcmNativeRegistrationAsync instead.")]
+        internal Task<GcmRegistrationDescription> CreateGcmNativeRegistrationAsync(string gcmRegistrationId, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new GcmRegistrationDescription(gcmRegistrationId, tags));
         }
@@ -1054,7 +1101,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<GcmTemplateRegistrationDescription> CreateGcmTemplateRegistrationAsync(string gcmRegistrationId, string jsonPayload)
+        [Obsolete("CreateGcmTemplateRegistrationAsync is deprecated, please use CreateFcmTemplateRegistrationAsync instead.")]
+        internal Task<GcmTemplateRegistrationDescription> CreateGcmTemplateRegistrationAsync(string gcmRegistrationId, string jsonPayload)
         {
             return CreateGcmTemplateRegistrationAsync(gcmRegistrationId, jsonPayload, null);
         }
@@ -1068,9 +1116,62 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<GcmTemplateRegistrationDescription> CreateGcmTemplateRegistrationAsync(string gcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
+        [Obsolete("CreateGcmTemplateRegistrationAsync is deprecated, please use CreateFcmTemplateRegistrationAsync instead.")]
+        internal Task<GcmTemplateRegistrationDescription> CreateGcmTemplateRegistrationAsync(string gcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new GcmTemplateRegistrationDescription(gcmRegistrationId, jsonPayload, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM native registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmRegistrationDescription> CreateFcmNativeRegistrationAsync(string fcmRegistrationId)
+        {
+            return CreateFcmNativeRegistrationAsync(fcmRegistrationId, null);
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM native registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="tags">The tags.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmRegistrationDescription> CreateFcmNativeRegistrationAsync(string fcmRegistrationId, IEnumerable<string> tags)
+        {
+            return CreateRegistrationAsync(new FcmRegistrationDescription(fcmRegistrationId, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM template registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmTemplateRegistrationDescription> CreateFcmTemplateRegistrationAsync(string fcmRegistrationId, string jsonPayload)
+        {
+            return CreateFcmTemplateRegistrationAsync(fcmRegistrationId, jsonPayload, null);
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM template registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="tags">The tags.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmTemplateRegistrationDescription> CreateFcmTemplateRegistrationAsync(string fcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
+        {
+            return CreateRegistrationAsync(new FcmTemplateRegistrationDescription(fcmRegistrationId, jsonPayload, tags));
         }
 
         #region Baidu Create Registration
@@ -1683,6 +1784,11 @@ namespace Microsoft.Azure.NotificationHubs
                 AddToQuery(requestUri, "&direct");
             }
 
+            // Convert FcmNotification into GcmNotification
+            if (notification.GetType().Name == "FcmNotification")
+            {
+                notification = new GcmNotification((FcmNotification) notification);
+            }
 
             notification.ValidateAndPopulateHeaders();
 
@@ -1738,6 +1844,12 @@ namespace Microsoft.Azure.NotificationHubs
         {
             var requestUri = GetGenericRequestUriBuilder();
             requestUri.Path += "schedulednotifications";
+
+            // Convert FcmNotification into GcmNotification
+            if (notification.GetType().Name == "FcmNotification")
+            {
+                notification = new GcmNotification((FcmNotification) notification);
+            }
 
             notification.ValidateAndPopulateHeaders();
 
@@ -1887,6 +1999,22 @@ namespace Microsoft.Azure.NotificationHubs
                 {
                     using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     {
+                        // Convert GcmTemplateRegistrationDescription returned by service into FcmTemplateRegistrationDescription to match method's return type.
+                        if (registration is FcmTemplateRegistrationDescription)
+                        {
+                            var gcmTemplateRegistrationResponse = await ReadEntityAsync<GcmTemplateRegistrationDescription>(responseStream).ConfigureAwait(false);
+                            var fcmTemplateRegistrationDescription = new FcmTemplateRegistrationDescription(gcmTemplateRegistrationResponse);
+                            return (fcmTemplateRegistrationDescription as TRegistration);
+                        }
+
+                        // Convert GcmRegistrationDescription returned by service into FcmRegistrationDescription to match method's return type.
+                        if (registration is FcmRegistrationDescription)
+                        {
+                            var gcmRegistrationResponse = await ReadEntityAsync<GcmRegistrationDescription>(responseStream).ConfigureAwait(false);
+                            var fcmRegistrationDescription = new FcmRegistrationDescription(gcmRegistrationResponse);
+                            return (fcmRegistrationDescription as TRegistration);
+                        }
+                        
                         return await ReadEntityAsync<TRegistration>(responseStream).ConfigureAwait(false);
                     }
                 }
@@ -1903,6 +2031,20 @@ namespace Microsoft.Azure.NotificationHubs
             {
                 using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
+                    if (typeof(FcmTemplateRegistrationDescription).IsAssignableFrom(typeof(TEntity)))
+                    {
+                        var gcmTemplateRegistrationResponse = await ReadEntityAsync<GcmTemplateRegistrationDescription>(responseStream).ConfigureAwait(false);
+                        var fcmTemplateRegistrationDescription = new FcmTemplateRegistrationDescription(gcmTemplateRegistrationResponse);
+                        return (fcmTemplateRegistrationDescription as TEntity);
+                    }
+
+                    if (typeof(FcmRegistrationDescription).IsAssignableFrom(typeof(TEntity)))
+                    {
+                        var gcmRegistrationResponse = await ReadEntityAsync<GcmRegistrationDescription>(responseStream).ConfigureAwait(false);
+                        var fcmRegistrationDescription = new FcmRegistrationDescription(gcmRegistrationResponse);
+                        return (fcmRegistrationDescription as TEntity);
+                    }
+
                     return await ReadEntityAsync<TEntity>(responseStream).ConfigureAwait(false);
                 }
 

--- a/src/Microsoft.Azure.NotificationHubs/NotificationPlatform.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationPlatform.cs
@@ -32,10 +32,18 @@ namespace Microsoft.Azure.NotificationHubs
         Mpns=3,
 
         /// <summary>
-        /// GCM Installation Platform
+        /// FCM Installation Platform
         /// </summary>
+        ///
+        /// <remarks>
+        /// The "gcm" value is intentional. As of version 3.0.0, all GCM related methods are hidden from
+        /// the end-user in order to incentivize them to switch their code over to FCM methods. However,
+        /// due to the backend having issues dealing with FCM models, the SDK converts them to GCM prior
+        /// sending to the service, so the "Fcm" value will be sent as "Gcm". Both SDK and backend still
+        /// transparently operate GCM models while allowing end-user to work with FCM classes.
+        /// </remarks>
         [EnumMember(Value = "gcm")]
-        Gcm=4,
+        Fcm=4,
 
         /// <summary>
         /// ADM Installation Platform

--- a/src/Microsoft.Azure.NotificationHubs/PNSCredential.cs
+++ b/src/Microsoft.Azure.NotificationHubs/PNSCredential.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.NotificationHubs
     [DataContract(Name = ManagementStrings.PnsCredential, Namespace = ManagementStrings.Namespace)]
     [KnownType(typeof(ApnsCredential))]
     [KnownType(typeof(GcmCredential))]
+    [KnownType(typeof(FcmCredential))]
     [KnownType(typeof(MpnsCredential))]
     [KnownType(typeof(WnsCredential))]
     [KnownType(typeof(AdmCredential))]

--- a/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.NotificationHubs
     /// </summary>
     [DataContract(Namespace = ManagementStrings.Namespace)]
     [KnownType(typeof(GcmRegistrationDescription))]
+    [KnownType(typeof(FcmRegistrationDescription))]
     [KnownType(typeof(AppleRegistrationDescription))]
     [KnownType(typeof(AppleTemplateRegistrationDescription))]
     [KnownType(typeof(WindowsRegistrationDescription))]
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.NotificationHubs
     [KnownType(typeof(MpnsRegistrationDescription))]
     [KnownType(typeof(MpnsTemplateRegistrationDescription))]
     [KnownType(typeof(GcmTemplateRegistrationDescription))]
+    [KnownType(typeof(FcmTemplateRegistrationDescription))]
     [KnownType(typeof(AdmRegistrationDescription))]
     [KnownType(typeof(AdmTemplateRegistrationDescription))]
     [KnownType(typeof(BaiduRegistrationDescription))]

--- a/src/Microsoft.Azure.NotificationHubs/SRClient.Designer.cs
+++ b/src/Microsoft.Azure.NotificationHubs/SRClient.Designer.cs
@@ -1201,6 +1201,13 @@ namespace Microsoft.Azure.NotificationHubs {
                 return ResourceManager.GetString("GcmRequiredProperties", Culture);
             }
         }
+
+        /// <summary>Gets localized string like: FCM Registration Id is invalid.</summary>
+        internal static string FCMRegistrationInvalidId {
+            get {
+                return ResourceManager.GetString("FCMRegistrationInvalidId", Culture);
+            }
+        }
         
         /// <summary>Gets localized string like: GoogleApiKey is either not specified or invalid.</summary>
         internal static string GoogleApiKeyNotSpecified {

--- a/src/Microsoft.Azure.NotificationHubs/SRClient.resx
+++ b/src/Microsoft.Azure.NotificationHubs/SRClient.resx
@@ -988,6 +988,9 @@
   <data name="GcmRequiredProperties" xml:space="preserve">
     <value>Only GoogleApiKey and GcmEndpoint are required.</value>
   </data>
+  <data name="FCMRegistrationInvalidId" xml:space="preserve">
+    <value>FCM Registration Id is invalid.</value>
+  </data>
   <data name="GoogleApiKeyNotSpecified" xml:space="preserve">
     <value>GoogleApiKey is either not specified or invalid.</value>
   </data>


### PR DESCRIPTION
* Merge changes from PR#14 Added FMC support

* Convert FCM registration into GCM when serializing

* Convert notifications from FCM to GCM when sending

Notification Hubs at the moment aren't aware of existence of
FCMNotificaiton type and cannon't handle it when it arrives from the
SDK. For that reason, the FCMNotifcation is converted into
GCMNotificiation prior to being sent.

* Convert server response (GCMReg) into FCMReg type

When an FcmRegistrationDescription or FcmTemplateRegistrationDescription
are created or updated via CreateOrUpdateRegistrationImplAsync, they are
converted into respective GCM counterparts before being sent to the
service. Because of that once request has been processed, the service
returns GCM type of registration which mismatches the
CreateOrUpdateRegistrationImplAsync return type (defined by the type of
registration parameter). To avoid that issue, GCM type from server's
response is converted into its FCM alternative when needed.

* Increase PackageVersion to 2.0.3

* Fix incorrect server response conversion order

GcmTempalteRegistrationDescription returned by server was mistakenly
converted into FcmRegistrationDescription as FcmTemplateRegistrationDescription
is a subclass of FcmRegistrationDescription and that part of hierarchy
was tested first and the test succeeded, thus never reaching
FcmTemplateRegistrationDescription.

* Increase PackageVersion to 2.1.0

* Add GCM to FCM conversion into GetEntityImplAsync

The conversion is added to prevent an issue where the server is probed
for registration description by its Id and the returned Gcm registration
mismatches FcmRegistration specified by the user as generic type,
causing type casting error.

GetEntityImplAsync() is used in GetRegistrationAsync(), which seems to
be broken as it commented out in samples and only tested for failure in
tests.

* Hide GCM functionality from SDK user, ver. 3.0.0

Marks all GCM-related types and methods as 'internal' in order to
incentivize a user to switch their code to FCM methods and types.

* Update Samples to use FCM functionality, ver.3.0.0

* Update tests to use FCM methods and types

* Fix incomplete GCM to FCM copy constructor