### PR TITLE
Fix missing GCM to FCM conversion

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
+++ b/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>3.0.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1.0</VersionPrefix>
     <PackageId>Microsoft.Azure.NotificationHubs</PackageId>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>3.0.1</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=218949</PackageLicenseUrl>
     <PackageProjectUrl>https://aka.ms/NHNuget</PackageProjectUrl>
@@ -25,6 +25,7 @@
     </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft Azure windowsazureofficial NotificationHub Notifications Notification Hub Push Windows Phone iOS Android Baidu Kindle Amazon</PackageTags>
+    <Version>3.0.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -2139,7 +2139,7 @@ namespace Microsoft.Azure.NotificationHubs
 
             using (var xmlReader = XmlReader.Create(source, new XmlReaderSettings { Async = true }))
             {
-                // Advancing to the first element skiping non-content nodes
+                // Advancing to the first element skipping non-content nodes
                 await xmlReader.MoveToContentAsync().ConfigureAwait(false);
 
                 if (!xmlReader.IsStartElement("feed"))
@@ -2150,11 +2150,25 @@ namespace Microsoft.Azure.NotificationHubs
                 // Advancing to the next Atom entry
                 while (xmlReader.ReadToFollowing("entry"))
                 {
-                    // Anvancing to content of the Atom entry
+                    // Advancing to content of the Atom entry
                     if (xmlReader.ReadToDescendant("content"))
                     {
                         xmlReader.ReadStartElement();
-                        result.Add((TEntity)_entitySerializer.Deserialize(xmlReader, xmlReader.Name));
+                        var entity = (TEntity)_entitySerializer.Deserialize(xmlReader, xmlReader.Name);
+
+                        if (entity is GcmTemplateRegistrationDescription)
+                        {
+                            var fcmTemplateRegistrationDescription = new FcmTemplateRegistrationDescription(entity as GcmTemplateRegistrationDescription);
+                            entity = (fcmTemplateRegistrationDescription as TEntity);
+                        }
+                        
+                        if (entity is GcmRegistrationDescription)
+                        {
+                            var fcmRegistrationDescription = new FcmRegistrationDescription(entity as GcmRegistrationDescription);
+                            entity = (fcmRegistrationDescription as TEntity);
+                        }
+                        
+                        result.Add(entity);
                     }
                 }
             }


### PR DESCRIPTION
Fixes an issue of 
- GetRegistrationsByChannelAsync
- GetRegistrationsByTagAsync
- GetAllRegistrationsAsync

occasionally returning Gcm* types due to missing coversion in `ReadEntitiesAsync`.

This PR increases the package Patch version by one, to `3.0.1`.