### PR TITLE
Fix for: #38  throws MessagingEntityNotFoundException if it can't find registration

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetExistingRegistration.http
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetExistingRegistration.http
@@ -1,0 +1,59 @@
+{
+    "HttpCalls": [
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04&$top=100",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:25 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=feed; charset=utf-8"
+            },
+            "Content": "<feed xmlns=\"http://www.w3.org/2005/Atom\"><title type=\"text\">Registrations</title><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100</id><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100\"/><entry a:etag=\"W/&quot;1&quot;\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100</id><title type=\"text\">293940965926914880-1598107072140701410-1</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100\"/><content type=\"application/xml\"><WindowsRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999Z</ExpirationTime><RegistrationId>293940965926914880-1598107072140701410-1</RegistrationId><Tags>tag1</Tags><PushVariables>{\"var1\":\"value1\"}</PushVariables><ChannelUri>https://some.url/</ChannelUri><SecondaryTileName>Tile name</SecondaryTileName></WindowsRegistrationDescription></content></entry></feed>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"1\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8",
+                "Content-Location": "https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04"
+            },
+            "Content": "<entry a:etag=\"W/&quot;1&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"2\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8"
+            },
+            "Content": "<entry a:etag=\"W/&quot;2&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:27Z</published><updated>2018-11-07T00:18:27Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>2</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><Tags>tag1</Tags><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        }
+    ],
+    "Guids": []
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
@@ -1,0 +1,59 @@
+{
+    "HttpCalls": [
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04&$top=100",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:25 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=feed; charset=utf-8"
+            },
+            "Content": "<feed xmlns=\"http://www.w3.org/2005/Atom\"><title type=\"text\">Registrations</title><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100</id><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100\"/><entry a:etag=\"W/&quot;1&quot;\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100</id><title type=\"text\">293940965926914880-1598107072140701410-1</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100\"/><content type=\"application/xml\"><WindowsRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999Z</ExpirationTime><RegistrationId>293940965926914880-1598107072140701410-1</RegistrationId><Tags>tag1</Tags><PushVariables>{\"var1\":\"value1\"}</PushVariables><ChannelUri>https://some.url/</ChannelUri><SecondaryTileName>Tile name</SecondaryTileName></WindowsRegistrationDescription></content></entry></feed>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"1\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8",
+                "Content-Location": "https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04"
+            },
+            "Content": "<entry a:etag=\"W/&quot;1&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"2\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8"
+            },
+            "Content": "<entry a:etag=\"W/&quot;2&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:27Z</published><updated>2018-11-07T00:18:27Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>2</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><Tags>tag1</Tags><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        }
+    ],
+    "Guids": []
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
@@ -53,6 +53,31 @@
                 "Content-Type": "application/atom+xml; type=entry; charset=utf-8"
             },
             "Content": "<entry a:etag=\"W/&quot;2&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:27Z</published><updated>2018-11-07T00:18:27Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>2</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><Tags>tag1</Tags><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 404,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/xml; charset=utf-8",
+            },
+            "Content": "<Error><Code>404</Code><Detail>.TrackingId:33e8ef5f-b183-4f11-9ce0-ce01afffd462_G8,TimeStamp:8/14/2019 4:58:19 AM</Detail></Error>"
         }
     ],
     "Guids": []

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
@@ -517,6 +517,37 @@ namespace Microsoft.Azure.NotificationHubs.Tests
         }
 
         [Fact]
+        public async Task RegistrationExistsAsync_GetExistingRegistration()
+        {
+            LoadMockData();
+            await DeleteAllRegistrationsAndInstallations();
+
+            var appleRegistration = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new []{ "tag1" });
+            var createdRegistration = await _hubClient.CreateRegistrationAsync(appleRegistration);
+
+            var registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.True(registrationExists);
+        }
+
+        [Fact]
+        public async Task RegistrationExistsAsync_GetNonExistingRegistration()
+        {
+            LoadMockData();
+            await DeleteAllRegistrationsAndInstallations();
+
+            var appleRegistration = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new []{ "tag1" });
+            var createdRegistration = await _hubClient.CreateRegistrationAsync(appleRegistration);
+
+            var registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.True(registrationExists);
+
+            await _hubClient.DeleteRegistrationAsync(createdRegistration.RegistrationId);
+
+            registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.False(registrationExists);
+        }
+
+        [Fact]
         public async Task UpdateRegistrationAsync_UpdateAppleNativeRegistration_GetUpdatedRegistrationBack()
         {
             LoadMockData();

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -2010,11 +2010,13 @@ namespace Microsoft.Azure.NotificationHubs
             using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
             using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
             {
+                if (response.Content == null)
+                    return default;
+
                 using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {
                     return await ReadEntityAsync<TEntity>(responseStream).ConfigureAwait(false);
                 }
-
             }
         }
 

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -1367,7 +1367,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when registrationId is null</exception>
-        public Task<TRegistrationDescription> GetRegistrationAsync<TRegistrationDescription>(string registrationId, bool throwIfNotFound = false) where TRegistrationDescription : RegistrationDescription
+        public Task<TRegistrationDescription> GetRegistrationAsync<TRegistrationDescription>(string registrationId, bool throwIfNotFound = true) where TRegistrationDescription : RegistrationDescription
         {
             if (string.IsNullOrWhiteSpace(registrationId))
             {
@@ -1522,7 +1522,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public async Task<bool> RegistrationExistsAsync(string registrationId)
         {
-            return await GetRegistrationAsync<RegistrationDescription>(registrationId, true).ConfigureAwait(false) != null;
+            return await GetRegistrationAsync<RegistrationDescription>(registrationId, false).ConfigureAwait(false) != null;
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -2011,7 +2011,7 @@ namespace Microsoft.Azure.NotificationHubs
             using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
             {
                 if (response.Content == null)
-                    return default;
+                    return null;
 
                 using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                 {


### PR DESCRIPTION
#38  throws MessagingEntityNotFoundException if it can't find registration

I fixed the issue when MessagingEntityNotFoundException was being thrown if a registration was not found in "RegistrationExistsAsync" method. The root issue was caused by response.Content being NULL and therefore any operations on that property were failing.
