### PR TITLE
Update notificationId ArgumentNullException message in GetNotificationOutcomeDetailsAsync

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -649,7 +649,7 @@ namespace Microsoft.Azure.NotificationHubs
         {
             if (string.IsNullOrWhiteSpace(notificationId))
             {
-                throw new ArgumentNullException("notificationId");
+                throw new ArgumentNullException(nameof(notificationId), "value may not be null, and must contain more than just whitespace");
             }
 
             var requestUri = GetGenericRequestUriBuilder();


### PR DESCRIPTION
This value will rarely ever be null, as the default value for NotificationID is the empty string.

While debugging #67, this was somewhat confusing. Hopefully this change will provide guidance in the future.