### PR TITLE
Override NotificationHubConnectionStringBuilder.ToString()

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace Microsoft.Azure.NotificationHubs.Tests
+{
+    public class NotificationHubConnectionStringBuilderTests
+    {
+        [Fact]
+        public void ToStringShouldReturnAllProperties()
+        {
+            var b = new NotificationHubConnectionStringBuilder("Endpoint=sb://my-namespace.servicebus.windows.net/")
+            {
+                SharedAccessKeyName = "key-name",
+                SharedAccessKey = "secret"
+            };
+            
+            Assert.Equal(
+            "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=key-name;SharedAccessKey=secret",
+            b.ToString());
+        }
+    }
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Azure.NotificationHubs.Tests
             };
             
             Assert.Equal(
-            "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=key-name;SharedAccessKey=secret",
-            b.ToString());
+                "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=key-name;SharedAccessKey=secret",
+                b.ToString());
         }
     }
 }

--- a/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\NotificationHubClientTest.cs" Link="NotificationHubClientTest.cs" />
+    <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\NotificationHubConnectionStringBuilderTests.cs" Link="NotificationHubConnectionStringBuilderTests.cs" />
     <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\TestServerProxy.cs" Link="TestServerProxy.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubConnectionStringBuilder.cs
@@ -99,5 +99,14 @@ namespace Microsoft.Azure.NotificationHubs
                 throw new ArgumentException(exception.Message, "connectionString", exception);
             }
         }
+
+        /// <summary>
+        /// Returns string representation of parsed connection string
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"Endpoint={Endpoint};SharedAccessKeyName={SharedAccessKeyName};SharedAccessKey={SharedAccessKey}";
+        }
     }
 }


### PR DESCRIPTION
to return string representation of properties