### PR TITLE
Merge master, fix test reference failures

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.2 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [many more](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets Microsoft's [definition](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)) of a security vulnerability, please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/Samples/AzFunctions/AzFunctionsSample/AzureFunctionsSample.csproj
+++ b/Samples/AzFunctions/AzFunctionsSample/AzureFunctionsSample.csproj
@@ -4,7 +4,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.*" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/CreateHubSample/CreateHubSample/CreateHubSample.csproj
+++ b/Samples/CreateHubSample/CreateHubSample/CreateHubSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Samples/NotifyUsers/AppBackend/Models/Notifications.cs
+++ b/Samples/NotifyUsers/AppBackend/Models/Notifications.cs
@@ -10,8 +10,7 @@ namespace AppBackend.Models
 
         private Notifications()
         {
-//            Hub = NotificationHubClient.CreateClientFromConnectionString("<Enter your connection string with full access", "your hub name");
-            Hub = NotificationHubClient.CreateClientFromConnectionString("Endpoint=sb://wesmc-hub-ns.servicebus.windows.net/;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=Ztd5lKYAovSs+g3gs0M/EkbVRuIVw7ft4BUylZRtcss=", "wesmc-hub");
+            Hub = NotificationHubClient.CreateClientFromConnectionString("<Enter your connection string with full access", "your hub name");
         }
     }
 }

--- a/Samples/NotifyUsers/AppBackend/packages.config
+++ b/Samples/NotifyUsers/AppBackend/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
-  <package id="Microsoft.Azure.NotificationHubs" version="3.0.2" targetFramework="net472" />
+  <package id="Microsoft.Azure.NotificationHubs" version="3.3.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Caching.Abstractions" version="2.2.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Caching.Memory" version="2.2.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net472" />

--- a/Samples/ParseFeedbackSample/ParseFeedbackSample/ParseFeedbackSample.csproj
+++ b/Samples/ParseFeedbackSample/ParseFeedbackSample/ParseFeedbackSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Samples/ParseFeedbackSample/ParseFeedbackSample/Program.cs
+++ b/Samples/ParseFeedbackSample/ParseFeedbackSample/Program.cs
@@ -50,7 +50,14 @@ namespace ParseFeedbackSample
 
             // Send notifications to all users
             var outcomeFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent);
-            
+
+            // The Notification ID is only available for Standard SKUs. For Basic and Free SKUs the API to get notification outcome details can not be called.
+            if (string.IsNullOrEmpty(outcomeFcm.NotificationId))
+            {
+                Console.WriteLine($"FCM has no outcome, due to it is only available for Standard SKU pricing tier.");
+                return;
+            }
+
             // Gather send outcome
             var fcmOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeFcm);
 

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -63,6 +63,16 @@ namespace UwpSample
 }
 ```
 
+## CreateHubSample
+Sample dotnet core WebApi application for sending push notifications.
+
+Update the '/WebApiSample/WebApiSample/Models/Notification.cs' with your Notification Hubs 'DefaultFullSharedAccessSignature' Access Policy connection string and 'Hub name', than execute the sample as such:
+
+```
+cd WebApiSample
+dotnet run
+```
+
 To run the sample open the solution, select UwpSample as a startup project, and hit F5.
 
 ## Azure Functions

--- a/Samples/RegistrationSample/RegistrationSample/RegistrationSample.csproj
+++ b/Samples/RegistrationSample/RegistrationSample/RegistrationSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Samples/SendPushSample/SendPushSample/Program.cs
+++ b/Samples/SendPushSample/SendPushSample/Program.cs
@@ -54,11 +54,10 @@ namespace SendPushSample
                 case SampleConfiguration.Operation.Broadcast:
                     // Notification groups should be created on client side
                     var outcomeFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent);
+                    await GetPushDetailsAndPrintOutcome("FCM", nhClient, outcomeFcm);
+
                     var outcomeSilentFcm = await nhClient.SendFcmNativeNotificationAsync(FcmSampleSilentNotificationContent);
-                    var fcmOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeFcm);
-                    var fcmSilentOutcomeDetails = await WaitForThePushStatusAsync("FCM", nhClient, outcomeSilentFcm);
-                    PrintPushOutcome("FCM", fcmOutcomeDetails, fcmOutcomeDetails.FcmOutcomeCounts);
-                    PrintPushOutcome("FCM Silent ", fcmSilentOutcomeDetails, fcmSilentOutcomeDetails.FcmOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("FCM Silent", nhClient, outcomeSilentFcm);
 
                     // Send groupable notifications to iOS
                     var notification = new AppleNotification(AppleSampleNotificationContent);
@@ -68,37 +67,31 @@ namespace SendPushSample
                     }
 
                     var outcomeApns = await nhClient.SendNotificationAsync(notification);
+                    await GetPushDetailsAndPrintOutcome("APNS", nhClient, outcomeApns);
+
                     var outcomeSilentApns = await nhClient.SendAppleNativeNotificationAsync(AppleSampleSilentNotificationContent);
-                    var apnsOutcomeDetails = await WaitForThePushStatusAsync("APNS", nhClient, outcomeApns);
-                    var apnsSilentOutcomeDetails = await WaitForThePushStatusAsync("APNS", nhClient, outcomeSilentApns);
-                    PrintPushOutcome("APNS", apnsOutcomeDetails, apnsOutcomeDetails.ApnsOutcomeCounts);
-                    PrintPushOutcome("APNS Silent", apnsSilentOutcomeDetails, apnsSilentOutcomeDetails.ApnsOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("APNS Silent", nhClient, outcomeSilentApns);
 
                     var outcomeWns = await nhClient.SendWindowsNativeNotificationAsync(WnsSampleNotification);
-                    var wnsOutcomeDetails = await WaitForThePushStatusAsync("WNS", nhClient, outcomeWns);
-                    PrintPushOutcome("WNS", wnsOutcomeDetails, wnsOutcomeDetails.WnsOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("WNS", nhClient, outcomeWns);
 
                     break;
                 case SampleConfiguration.Operation.SendByTag:
                     // Send notifications by tag
                     var outcomeFcmByTag = await nhClient.SendFcmNativeNotificationAsync(FcmSampleNotificationContent, config.Tag ?? "fcm");
-                    var fcmTagOutcomeDetails = await WaitForThePushStatusAsync("FCM Tags", nhClient, outcomeFcmByTag);
-                    PrintPushOutcome("FCM Tags", fcmTagOutcomeDetails, fcmTagOutcomeDetails.FcmOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("FCM Tags", nhClient, outcomeFcmByTag);
 
                     var outcomeApnsByTag = await nhClient.SendAppleNativeNotificationAsync(AppleSampleNotificationContent, config.Tag ?? "apns");
-                    var apnsTagOutcomeDetails = await WaitForThePushStatusAsync("APNS Tags", nhClient, outcomeApnsByTag);
-                    PrintPushOutcome("APNS Tags", apnsTagOutcomeDetails, apnsTagOutcomeDetails.ApnsOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("APNS Tags", nhClient, outcomeApnsByTag);
 
                     break;
                 case SampleConfiguration.Operation.SendByDevice:
                     // Send notifications by deviceId
                     var outcomeFcmByDeviceId = await nhClient.SendDirectNotificationAsync(CreateFcmNotification(), config.FcmDeviceId ?? fcmDeviceId);
-                    var fcmDirectSendOutcomeDetails = await WaitForThePushStatusAsync("FCM direct", nhClient, outcomeFcmByDeviceId);
-                    PrintPushOutcome("FCM Direct", fcmDirectSendOutcomeDetails, fcmDirectSendOutcomeDetails.ApnsOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("FCM Direct", nhClient, outcomeFcmByDeviceId);
 
                     var outcomeApnsByDeviceId = await nhClient.SendDirectNotificationAsync(CreateApnsNotification(), config.AppleDeviceId ?? appleDeviceId);
-                    var apnsDirectSendOutcomeDetails = await WaitForThePushStatusAsync("APNS direct", nhClient, outcomeApnsByDeviceId);
-                    PrintPushOutcome("APNS Direct", apnsDirectSendOutcomeDetails, apnsDirectSendOutcomeDetails.ApnsOutcomeCounts);
+                    await GetPushDetailsAndPrintOutcome("APNS Direct", nhClient, outcomeApnsByDeviceId);
 
                     break;
                 default:
@@ -154,6 +147,11 @@ namespace SendPushSample
             Console.WriteLine($"{pnsType} error details URL: {details.PnsErrorDetailsUri}");
         }
 
+        private static void PrintPushNoOutcome(string pnsType)
+        {
+            Console.WriteLine($"{pnsType} has no outcome due to it is only available for Standard SKU pricing tier.");
+        }
+
         private static SampleConfiguration LoadConfiguration(string[] args)
         {
             ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
@@ -163,6 +161,47 @@ namespace SendPushSample
             var sampleConfig = new SampleConfiguration();
             configRoot.Bind(sampleConfig);
             return sampleConfig;
+        }
+
+        private static async Task GetPushDetailsAndPrintOutcome(
+            string pnsType,
+            NotificationHubClient nhClient,
+            NotificationOutcome notificationOutcome)
+        {
+            // The Notification ID is only available for Standard SKUs. For Basic and Free SKUs the API to get notification outcome details can not be called.
+            if (string.IsNullOrEmpty(notificationOutcome.NotificationId))
+            {
+                PrintPushNoOutcome(pnsType);
+                return;
+            }
+
+            var details = await WaitForThePushStatusAsync(pnsType, nhClient, notificationOutcome);
+            NotificationOutcomeCollection collection = null;
+            switch (pnsType)
+            {
+                case "FCM":
+                case "FCM Silent":
+                case "FCM Tags":
+                case "FCM Direct":
+                    collection = details.FcmOutcomeCounts;
+                    break;
+
+                case "APNS":
+                case "APNS Silent":
+                case "APNS Tags":
+                case "APNS Direct":
+                    collection = details.ApnsOutcomeCounts;
+                    break;
+
+                case "WNS":
+                    collection = details.WnsOutcomeCounts;
+                    break;
+                default:
+                    Console.WriteLine("Invalid Sendtype");
+                    break;
+            }
+
+            PrintPushOutcome(pnsType, details, collection);
         }
     }
 }

--- a/Samples/SendPushSample/SendPushSample/SendPushSample.csproj
+++ b/Samples/SendPushSample/SendPushSample/SendPushSample.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.3.1-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
-    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Samples/UwpSample/UwpSample/App.xaml.cs
+++ b/Samples/UwpSample/UwpSample/App.xaml.cs
@@ -1,12 +1,12 @@
 ﻿using System;
+using Microsoft.Azure.NotificationHubs;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
+using Windows.Networking.PushNotifications;
+using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
-using Windows.Networking.PushNotifications;
-using Microsoft.WindowsAzure.Messaging;
-using Windows.UI.Popups;
 
 namespace UwpSample
 {
@@ -96,17 +96,17 @@ namespace UwpSample
         {
             var channel = await PushNotificationChannelManager.CreatePushNotificationChannelForApplicationAsync();
 
-            var hub = new NotificationHub(Secrets.HubName, Secrets.HubConnectionString);
-            var result = await hub.RegisterNativeAsync(channel.Uri);
-
-            // Displays the registration ID so you know it was successful
-            if (result.RegistrationId != null)
+            var hub = new NotificationHubClient(Secrets.HubName, Secrets.HubConnectionString);
+            await hub.CreateOrUpdateInstallationAsync(new Installation
             {
-                var dialog = new MessageDialog("Registration successful: " + result.RegistrationId);
-                dialog.Commands.Add(new UICommand("OK"));
-                await dialog.ShowAsync();
-            }
+                Platform = NotificationPlatform.Wns,
+                InstallationId = "myid",
+                PushChannel = channel.Uri
+            });
 
+            var dialog = new MessageDialog("Registration successful");
+            dialog.Commands.Add(new UICommand("OK"));
+            await dialog.ShowAsync();
         }
     }
 }

--- a/Samples/UwpSample/UwpSample/UwpSample.csproj
+++ b/Samples/UwpSample/UwpSample/UwpSample.csproj
@@ -11,20 +11,25 @@
     <AssemblyName>UwpSample</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateKeyFile>UwpSample_StoreKey.pfx</PackageCertificateKeyFile>
-    <PackageCertificateThumbprint>5E7E8BEEEA11F8B72A1A8308949B84787002442C</PackageCertificateThumbprint>
+    <PackageCertificateKeyFile>
+    </PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>2E2C56B6776BE1212A114FF929D0AFFDCFDF242F</PackageCertificateThumbprint>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxAutoIncrementPackageRevision>False</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>x86|x64</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x86|x64|arm</AppxBundlePlatforms>
     <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
+    <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <GenerateTestArtifacts>True</GenerateTestArtifacts>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -112,8 +117,6 @@
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="UwpSample_StoreKey.pfx" />
-    <None Include="UwpSample_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Package.StoreAssociation.xml" />
@@ -137,11 +140,11 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.NotificationHubs">
+      <Version>3.3.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.1.7</Version>
-    </PackageReference>
-    <PackageReference Include="WindowsAzure.Messaging.Managed">
-      <Version>0.1.7.9</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/Samples/WebApiSample/WebApiSample.sln
+++ b/Samples/WebApiSample/WebApiSample.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppBackend", "WebApiSample\AppBackend.csproj", "{CFBBDF7B-4B3B-4076-91E0-796E7AAF0CDE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CFBBDF7B-4B3B-4076-91E0-796E7AAF0CDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFBBDF7B-4B3B-4076-91E0-796E7AAF0CDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFBBDF7B-4B3B-4076-91E0-796E7AAF0CDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFBBDF7B-4B3B-4076-91E0-796E7AAF0CDE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2926066A-1414-4AA1-94B9-9E770115DD7E}
+	EndGlobalSection
+EndGlobal

--- a/Samples/WebApiSample/WebApiSample/AppBackend.csproj
+++ b/Samples/WebApiSample/WebApiSample/AppBackend.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <AssemblyName>AppBackend</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="3.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/WebApiSample/WebApiSample/AuthenticationTestMiddleware.cs
+++ b/Samples/WebApiSample/WebApiSample/AuthenticationTestMiddleware.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
+using System.Net;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AppBackend
+{
+    public class AuthenticationTestMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public AuthenticationTestMiddleware(RequestDelegate next) => _next = next;
+
+        public async Task Invoke(HttpContext context)
+        {
+            var authorizationHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+
+            if (authorizationHeader != null && authorizationHeader
+                .StartsWith("Basic ", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var authorizationUserAndPwdBase64 =
+                    authorizationHeader.Substring("Basic ".Length);
+                var authorizationUserAndPwd = Encoding.Default
+                    .GetString(Convert.FromBase64String(authorizationUserAndPwdBase64));
+                var user = authorizationUserAndPwd.Split(':')[0];
+                var password = authorizationUserAndPwd.Split(':')[1];
+
+                if (verifyUserAndPwd(user, password))
+                {
+                    // Attach the new principal object to the current HttpContext object
+                    context.User =
+                        new GenericPrincipal(new GenericIdentity(user), new string[0]);
+                    Thread.CurrentPrincipal =
+                        context.User;
+                }
+                else
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                    return;
+                }
+            }
+            else
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                return;
+            }
+
+            await _next.Invoke(context);
+        }
+
+        private bool verifyUserAndPwd(string user, string password)
+        {
+            // This is not a real authentication scheme.
+            return user == password;
+        }
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/Controllers/NotificationsController.cs
+++ b/Samples/WebApiSample/WebApiSample/Controllers/NotificationsController.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using AppBackend.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace AppBackend.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class NotificationsController : ControllerBase
+    {
+        [HttpPost]
+        public async Task<IActionResult> Post(string pns, [FromBody]string message, string to_tag)
+        {
+            var user = HttpContext.User.Identity.Name;
+            var userTag = new string[]
+            {
+                "username:" + to_tag,
+                "from:" + user
+            };
+
+            Microsoft.Azure.NotificationHubs.NotificationOutcome outcome = null;
+            var ret = HttpStatusCode.InternalServerError;
+
+            switch (pns.ToLower())
+            {
+                case "wns":
+                    // Windows 8.1 / Windows Phone 8.1
+                    var toast = @"<toast><visual><binding template=""ToastText01""><text id=""1"">" +
+                                "From " + user + ": " + message + "</text></binding></visual></toast>";
+                    outcome = await Notifications.Instance.Hub.SendWindowsNativeNotificationAsync(toast, userTag);
+                    break;
+                case "apns":
+                    // iOS
+                    var alert = "{\"aps\":{\"alert\":\"" + "From " + user + ": " + message + "\"}}";
+                    outcome = await Notifications.Instance.Hub.SendAppleNativeNotificationAsync(alert, userTag);
+                    break;
+                case "fcm":
+                    // Android
+                    var notif = "{ \"data\" : {\"message\":\"" + "From " + user + ": " + message + "\"}}";
+                    outcome = await Notifications.Instance.Hub.SendFcmNativeNotificationAsync(notif, userTag);
+                    break;
+            }
+
+            if (outcome != null)
+            {
+                if (!((outcome.State == Microsoft.Azure.NotificationHubs.NotificationOutcomeState.Abandoned) ||
+                    (outcome.State == Microsoft.Azure.NotificationHubs.NotificationOutcomeState.Unknown)))
+                {
+                    ret = HttpStatusCode.OK;
+                }
+            }
+
+            return StatusCode((int)ret);
+        }
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/Controllers/RegisterController.cs
+++ b/Samples/WebApiSample/WebApiSample/Controllers/RegisterController.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using AppBackend.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.NotificationHubs;
+using Microsoft.Azure.NotificationHubs.Messaging;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+using RouteAttribute = Microsoft.AspNetCore.Mvc.RouteAttribute;
+
+namespace AppBackend.Controllers
+{
+    [Route("api/[controller]")]
+    public class RegisterController : ControllerBase
+    {
+        private NotificationHubClient hub;
+
+        public RegisterController()
+        {
+            hub = Notifications.Instance.Hub;
+        }
+
+        public class DeviceRegistration
+        {
+            public string Platform { get; set; }
+            public string Handle { get; set; }
+            public string[] Tags { get; set; }
+        }
+
+        // POST api/register
+        // This creates a registration id
+        public async Task<string> Post(string handle = null)
+        {
+            string newRegistrationId = null;
+
+            // make sure there are no existing registrations for this push handle (used for iOS and Android)
+            if (handle != null)
+            {
+                var registrations = await hub.GetRegistrationsByChannelAsync(handle, 100);
+
+                foreach (var registration in registrations)
+                {
+                    if (newRegistrationId == null)
+                    {
+                        newRegistrationId = registration.RegistrationId;
+                    }
+                    else
+                    {
+                        await hub.DeleteRegistrationAsync(registration);
+                    }
+                }
+            }
+
+            if (newRegistrationId == null)
+                newRegistrationId = await hub.CreateRegistrationIdAsync();
+
+            return newRegistrationId;
+        }
+
+        // PUT api/register/5
+        // This creates or updates a registration (with provided channelURI) at the specified id
+        public async Task<IActionResult> Put(string id, DeviceRegistration deviceUpdate)
+        {
+            RegistrationDescription registration = null;
+            switch (deviceUpdate.Platform)
+            {
+                case "mpns":
+                    registration = new MpnsRegistrationDescription(deviceUpdate.Handle);
+                    break;
+                case "wns":
+                    registration = new WindowsRegistrationDescription(deviceUpdate.Handle);
+                    break;
+                case "apns":
+                    registration = new AppleRegistrationDescription(deviceUpdate.Handle);
+                    break;
+                case "fcm":
+                    registration = new FcmRegistrationDescription(deviceUpdate.Handle);
+                    break;
+                default:
+                    throw new HttpResponseException(HttpStatusCode.BadRequest);
+            }
+
+            registration.RegistrationId = id;
+            var username = HttpContext.User.Identity.Name;
+
+            // add check if user is allowed to add these tags
+            registration.Tags = new HashSet<string>(deviceUpdate.Tags);
+            registration.Tags.Add("username:" + username);
+
+            try
+            {
+                await hub.CreateOrUpdateRegistrationAsync(registration);
+            }
+            catch (MessagingException e)
+            {
+                ReturnGoneIfHubResponseIsGone(e);
+            }
+
+            return Ok();
+        }
+
+        // DELETE api/register/5
+        public async Task<IActionResult> Delete(string id)
+        {
+            await hub.DeleteRegistrationAsync(id);
+            return Ok();
+        }
+
+        private static void ReturnGoneIfHubResponseIsGone(MessagingException e)
+        {
+            var webex = e.InnerException as WebException;
+            if (webex.Status == WebExceptionStatus.ProtocolError)
+            {
+                var response = (HttpWebResponse)webex.Response;
+                if (response.StatusCode == HttpStatusCode.Gone)
+                    throw new HttpRequestException(HttpStatusCode.Gone.ToString());
+            }
+        }
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/Models/Notifications.cs
+++ b/Samples/WebApiSample/WebApiSample/Models/Notifications.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.Azure.NotificationHubs;
+
+namespace AppBackend.Models
+{
+    public class Notifications
+    {
+        public static Notifications Instance = new Notifications();
+
+        public NotificationHubClient Hub { get; set; }
+
+        private Notifications()
+        {
+            // Please update the following connection string with your hub's DefaultFullSharedAccessSignature with the full access such as Listen, Manage, Send
+            Hub = NotificationHubClient.CreateClientFromConnectionString("<your hub's DefaultFullSharedAccessSignature>",
+                                                                            "<hub name>");
+        }
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/Program.cs
+++ b/Samples/WebApiSample/WebApiSample/Program.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace AppBackend
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/Startup.cs
+++ b/Samples/WebApiSample/WebApiSample/Startup.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AppBackend
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseMiddleware<AuthenticationTestMiddleware>();
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseMvc();
+        }
+    }
+}

--- a/Samples/WebApiSample/WebApiSample/appsettings.Development.json
+++ b/Samples/WebApiSample/WebApiSample/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/Samples/WebApiSample/WebApiSample/appsettings.json
+++ b/Samples/WebApiSample/WebApiSample/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetExistingRegistration.http
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetExistingRegistration.http
@@ -1,0 +1,59 @@
+{
+    "HttpCalls": [
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04&$top=100",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:25 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=feed; charset=utf-8"
+            },
+            "Content": "<feed xmlns=\"http://www.w3.org/2005/Atom\"><title type=\"text\">Registrations</title><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100</id><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100\"/><entry a:etag=\"W/&quot;1&quot;\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100</id><title type=\"text\">293940965926914880-1598107072140701410-1</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100\"/><content type=\"application/xml\"><WindowsRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999Z</ExpirationTime><RegistrationId>293940965926914880-1598107072140701410-1</RegistrationId><Tags>tag1</Tags><PushVariables>{\"var1\":\"value1\"}</PushVariables><ChannelUri>https://some.url/</ChannelUri><SecondaryTileName>Tile name</SecondaryTileName></WindowsRegistrationDescription></content></entry></feed>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"1\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8",
+                "Content-Location": "https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04"
+            },
+            "Content": "<entry a:etag=\"W/&quot;1&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"2\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8"
+            },
+            "Content": "<entry a:etag=\"W/&quot;2&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:27Z</published><updated>2018-11-07T00:18:27Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>2</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><Tags>tag1</Tags><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        }
+    ],
+    "Guids": []
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/MockData/RegistrationExistsAsync_GetNonExistingRegistration.http
@@ -1,0 +1,84 @@
+{
+    "HttpCalls": [
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04&$top=100",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:25 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=feed; charset=utf-8"
+            },
+            "Content": "<feed xmlns=\"http://www.w3.org/2005/Atom\"><title type=\"text\">Registrations</title><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100</id><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations?api-version=2017-04&amp;$top=100\"/><entry a:etag=\"W/&quot;1&quot;\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100</id><title type=\"text\">293940965926914880-1598107072140701410-1</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04&amp;$top=100\"/><content type=\"application/xml\"><WindowsRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999Z</ExpirationTime><RegistrationId>293940965926914880-1598107072140701410-1</RegistrationId><Tags>tag1</Tags><PushVariables>{\"var1\":\"value1\"}</PushVariables><ChannelUri>https://some.url/</ChannelUri><SecondaryTileName>Tile name</SecondaryTileName></WindowsRegistrationDescription></content></entry></feed>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/293940965926914880-1598107072140701410-1?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"1\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8",
+                "Content-Location": "https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04"
+            },
+            "Content": "<entry a:etag=\"W/&quot;1&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:26Z</published><updated>2018-11-07T00:18:26Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>1</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "ETag": "W/\"2\"",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/atom+xml; type=entry; charset=utf-8"
+            },
+            "Content": "<entry a:etag=\"W/&quot;2&quot;\" xmlns=\"http://www.w3.org/2005/Atom\" xmlns:a=\"http://schemas.microsoft.com/ado/2007/08/dataservices/metadata\"><id>https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04</id><title type=\"text\">5267365982808935704-4914086341193203009-2</title><published>2018-11-07T00:18:27Z</published><updated>2018-11-07T00:18:27Z</updated><link rel=\"self\" href=\"https://sdk-sample-namespace.servicebus.windows.net/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04\"/><content type=\"application/xml\"><AppleRegistrationDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><ETag>2</ETag><ExpirationTime>9999-12-31T23:59:59.999</ExpirationTime><RegistrationId>5267365982808935704-4914086341193203009-2</RegistrationId><Tags>tag1</Tags><DeviceToken>62BCD3484834B7E2DC56733AC5509259230CC1BA82BA1AE7D06E91908A05A8FA</DeviceToken></AppleRegistrationDescription></content></entry>"
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 200,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Length": "0"
+            },
+            "Content": null
+        },
+        {
+            "RequestUriPath": "/sdk-sample-nh/registrations/5267365982808935704-4914086341193203009-2?api-version=2017-04",
+            "StatusCode": 404,
+            "Headers": {
+                "Date": "Wed, 07 Nov 2018 00:18:26 GMT",
+                "Transfer-Encoding": "chunked",
+                "Server": "Microsoft-HTTPAPI/2.0"
+            },
+            "ContentHeaders": {
+                "Content-Type": "application/xml; charset=utf-8",
+            },
+            "Content": "<Error><Code>404</Code><Detail>.TrackingId:33e8ef5f-b183-4f11-9ce0-ce01afffd462_G8,TimeStamp:8/14/2019 4:58:19 AM</Detail></Error>"
+        }
+    ],
+    "Guids": []
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubClientTest.cs
@@ -516,6 +516,37 @@ namespace Microsoft.Azure.NotificationHubs.Tests
         }
 
         [Fact]
+        public async Task RegistrationExistsAsync_GetExistingRegistration()
+        {
+            LoadMockData();
+            await DeleteAllRegistrationsAndInstallations();
+
+            var appleRegistration = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new []{ "tag1" });
+            var createdRegistration = await _hubClient.CreateRegistrationAsync(appleRegistration);
+
+            var registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.True(registrationExists);
+        }
+
+        [Fact]
+        public async Task RegistrationExistsAsync_GetNonExistingRegistration()
+        {
+            LoadMockData();
+            await DeleteAllRegistrationsAndInstallations();
+
+            var appleRegistration = new AppleRegistrationDescription(_configuration["AppleDeviceToken"], new []{ "tag1" });
+            var createdRegistration = await _hubClient.CreateRegistrationAsync(appleRegistration);
+
+            var registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.True(registrationExists);
+
+            await _hubClient.DeleteRegistrationAsync(createdRegistration.RegistrationId);
+
+            registrationExists = await _hubClient.RegistrationExistsAsync(createdRegistration.RegistrationId);
+            Assert.False(registrationExists);
+        }
+
+        [Fact]
         public async Task UpdateRegistrationAsync_UpdateAppleNativeRegistration_GetUpdatedRegistrationBack()
         {
             LoadMockData();

--- a/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetCore.Tests/NotificationHubConnectionStringBuilderTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace Microsoft.Azure.NotificationHubs.Tests
+{
+    public class NotificationHubConnectionStringBuilderTests
+    {
+        [Fact]
+        public void ToStringShouldReturnAllProperties()
+        {
+            var b = new NotificationHubConnectionStringBuilder("Endpoint=sb://my-namespace.servicebus.windows.net/")
+            {
+                SharedAccessKeyName = "key-name",
+                SharedAccessKey = "secret"
+            };
+            
+            Assert.Equal(
+                "Endpoint=sb://my-namespace.servicebus.windows.net/;SharedAccessKeyName=key-name;SharedAccessKey=secret",
+                b.ToString());
+        }
+    }
+}

--- a/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\NotificationHubClientTest.cs" Link="NotificationHubClientTest.cs" />
     <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\ManagementApiE2ETests.cs" Link="ManagementApiE2ETests.cs" />
+    <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\NotificationHubConnectionStringBuilderTests.cs" Link="NotificationHubConnectionStringBuilderTests.cs" />
     <Compile Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\TestServerProxy.cs" Link="TestServerProxy.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
+++ b/src/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests/Microsoft.Azure.NotificationHubs.DotNetFramework.Tests.csproj
@@ -16,9 +16,10 @@
     <None Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\appsettings.json" Link="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\MockData\*.http">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="..\Microsoft.Azure.NotificationHubs.DotNetCore.Tests\MockData\**"
+        CopyToOutputDirectory="PreserveNewest"
+        LinkBase="MockData\"
+    />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
@@ -29,10 +30,6 @@
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.msbuild" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="MockData\" />
-    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.NotificationHubs\Microsoft.Azure.NotificationHubs.csproj" />

--- a/src/Microsoft.Azure.NotificationHubs/CollectionQueryResult.cs
+++ b/src/Microsoft.Azure.NotificationHubs/CollectionQueryResult.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// Gets the continuation token.
         /// </summary>
         /// <value>
-        /// The continuation token.
+        /// The continuation token, which is null or empty when there is no additional data available in the query.
         /// </value>
         public string ContinuationToken
         {

--- a/src/Microsoft.Azure.NotificationHubs/Installation.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Installation.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.NotificationHubs
         public NotificationPlatform Platform { get; set; }
 
         /// <summary>
-        /// Gets expiration for the installation
+        /// Gets or sets expiration for the installation
         /// </summary>
         [JsonProperty(PropertyName = "expirationTime")]
         public DateTime? ExpirationTime { get; set; }

--- a/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
+++ b/src/Microsoft.Azure.NotificationHubs/Microsoft.Azure.NotificationHubs.csproj
@@ -5,9 +5,9 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <VersionPrefix>3.1.0.0</VersionPrefix>
+    <VersionPrefix>3.3.0.0</VersionPrefix>
     <PackageId>Microsoft.Azure.NotificationHubs</PackageId>
-    <PackageVersion>3.1.0</PackageVersion>
+    <PackageVersion>3.3.0</PackageVersion>
     <Authors>Microsoft</Authors>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=218949</PackageLicenseUrl>
     <PackageProjectUrl>https://aka.ms/NHNuget</PackageProjectUrl>
@@ -25,7 +25,7 @@
     </PackageReleaseNotes>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>Microsoft Azure windowsazureofficial NotificationHub Notifications Notification Hub Push Windows Phone iOS Android Baidu Kindle Amazon</PackageTags>
-    <Version>3.1.0.0</Version>
+    <Version>3.3.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Microsoft.Azure.NotificationHubs/NamespaceManager.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NamespaceManager.cs
@@ -12,6 +12,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.Azure.NotificationHubs.Auth;
@@ -250,13 +251,33 @@ namespace Microsoft.Azure.NotificationHubs
             CreateNotificationHubAsync(new NotificationHubDescription(hubName));
 
         /// <summary>
+        /// Creates a notification hub.
+        /// </summary>
+        /// <param name="hubName">The notification hub description name.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>An instance of the <see cref="NotificationHubDescription"/> class</returns>
+        public Task<NotificationHubDescription> CreateNotificationHubAsync(string hubName, CancellationToken cancellationToken) =>
+            CreateNotificationHubAsync(new NotificationHubDescription(hubName), cancellationToken);
+
+        /// <summary>
         /// Creates the notification hub asynchronously.
         /// </summary>
         /// <param name="description">The notification hub description.</param>
         /// <returns>A task that represents the asynchronous create hub operation</returns>
         public Task<NotificationHubDescription> CreateNotificationHubAsync(NotificationHubDescription description)
         {
-            return CreateOrUpdateNotificationHubAsync(description, false);
+            return CreateOrUpdateNotificationHubAsync(description, false, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the notification hub asynchronously.
+        /// </summary>
+        /// <param name="description">The notification hub description.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous create hub operation</returns>
+        public Task<NotificationHubDescription> CreateNotificationHubAsync(NotificationHubDescription description, CancellationToken cancellationToken)
+        {
+            return CreateOrUpdateNotificationHubAsync(description, false, cancellationToken);
         }
 
         /// <summary>
@@ -272,7 +293,18 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="path">The notification hub path.</param>
         /// <returns>A task that represents the asynchronous get hub operation</returns>
-        public async Task<NotificationHubDescription> GetNotificationHubAsync(string path)
+        public Task<NotificationHubDescription> GetNotificationHubAsync(string path)
+        {
+            return GetNotificationHubAsync(path, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Gets the notification hub asynchronously.
+        /// </summary>
+        /// <param name="path">The notification hub path.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous get hub operation</returns>
+        public async Task<NotificationHubDescription> GetNotificationHubAsync(string path, CancellationToken cancellationToken)
         {
             if (path == null)
             {
@@ -291,7 +323,7 @@ namespace Microsoft.Azure.NotificationHubs
                  var httpRequestMessage = CreateHttpRequest(HttpMethod.Get, requestUri.Uri);
 
                  return httpRequestMessage;
-             }).ConfigureAwait(false))
+             }, cancellationToken).ConfigureAwait(false))
             {
                 var xmlResponse = await GetXmlContent(response).ConfigureAwait(false);
                 if (xmlResponse.NodeType != XmlNodeType.None)
@@ -318,7 +350,17 @@ namespace Microsoft.Azure.NotificationHubs
         /// Gets the notification hubs asynchronously.
         /// </summary>
         /// <returns>A task that represents the asynchronous get hubs operation</returns>
-        public async Task<IEnumerable<NotificationHubDescription>> GetNotificationHubsAsync()
+        public Task<IEnumerable<NotificationHubDescription>> GetNotificationHubsAsync()
+        {
+            return GetNotificationHubsAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Gets the notification hubs asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous get hubs operation</returns>
+        public async Task<IEnumerable<NotificationHubDescription>> GetNotificationHubsAsync(CancellationToken cancellationToken)
         {
             var requestUri = new UriBuilder(Address)
             {
@@ -330,7 +372,7 @@ namespace Microsoft.Azure.NotificationHubs
                  var httpRequestMessage = CreateHttpRequest(HttpMethod.Get, requestUri.Uri);
 
                  return httpRequestMessage;
-             }).ConfigureAwait(false))
+             }, cancellationToken).ConfigureAwait(false))
             {
                 var result = new List<NotificationHubDescription>();
 
@@ -351,7 +393,7 @@ namespace Microsoft.Azure.NotificationHubs
                             xmlReader.ReadStartElement();
                             var hubName = xmlReader.Value;
 
-                            result.Add(await GetNotificationHubAsync(hubName).ConfigureAwait(false));
+                            result.Add(await GetNotificationHubAsync(hubName, cancellationToken).ConfigureAwait(false));
                         }
                     }
                 }
@@ -371,7 +413,17 @@ namespace Microsoft.Azure.NotificationHubs
         /// Delete the notification hub.
         /// </summary>
         /// <param name="path">The notification hub path.</param>
-        public async Task DeleteNotificationHubAsync(string path)
+        public Task DeleteNotificationHubAsync(string path)
+        {
+            return DeleteNotificationHubAsync(path, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Delete the notification hub.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <param name="path">The notification hub path.</param>
+        public async Task DeleteNotificationHubAsync(string path, CancellationToken cancellationToken)
         {
             if (path == null)
             {
@@ -390,7 +442,7 @@ namespace Microsoft.Azure.NotificationHubs
                 var httpRequestMessage = CreateHttpRequest(HttpMethod.Delete, requestUri.Uri);
 
                 return httpRequestMessage;
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -408,7 +460,18 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>A task that represents the asynchronous hub update operation</returns>
         public Task<NotificationHubDescription> UpdateNotificationHubAsync(NotificationHubDescription description)
         {
-            return CreateOrUpdateNotificationHubAsync(description, true);
+            return UpdateNotificationHubAsync(description, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the notification hub asynchronously.
+        /// </summary>
+        /// <param name="description">The description.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous hub update operation</returns>
+        public Task<NotificationHubDescription> UpdateNotificationHubAsync(NotificationHubDescription description, CancellationToken cancellationToken)
+        {
+            return CreateOrUpdateNotificationHubAsync(description, true, cancellationToken);
         }
 
         /// <summary>Checks whether a notifications hub exists.</summary>
@@ -422,11 +485,22 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="path">The notification hub path.</param>
         /// <returns>A task that represents the asynchronous hub check operation</returns>
-        public async Task<bool> NotificationHubExistsAsync(string path)
+        public Task<bool> NotificationHubExistsAsync(string path)
+        {
+            return NotificationHubExistsAsync(path, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Checks whether a notification hub exists asynchronously.
+        /// </summary>
+        /// <param name="path">The notification hub path.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous hub check operation</returns>
+        public async Task<bool> NotificationHubExistsAsync(string path, CancellationToken cancellationToken)
         {
             try
             {
-                var hubDescription = await GetNotificationHubAsync(path).ConfigureAwait(false);
+                var hubDescription = await GetNotificationHubAsync(path, cancellationToken).ConfigureAwait(false);
                 return String.Equals(hubDescription.Path, path, StringComparison.OrdinalIgnoreCase);
             }
             catch (MessagingEntityNotFoundException)
@@ -435,7 +509,7 @@ namespace Microsoft.Azure.NotificationHubs
             }
         }
 
-        private async Task<NotificationHubDescription> CreateOrUpdateNotificationHubAsync(NotificationHubDescription description, bool update)
+        private async Task<NotificationHubDescription> CreateOrUpdateNotificationHubAsync(NotificationHubDescription description, bool update, CancellationToken cancellationToken)
         {
             if (description == null)
             {
@@ -461,7 +535,7 @@ namespace Microsoft.Azure.NotificationHubs
                  }
 
                  return httpRequestMessage;
-             }).ConfigureAwait(false))
+             }, cancellationToken).ConfigureAwait(false))
             {
                 var xmlResponse = await GetXmlContent(response).ConfigureAwait(false);
                 var model = GetModelFromResponse<NotificationHubDescription>(xmlResponse);
@@ -474,7 +548,17 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="job">The job to submit.</param>
         /// <param name="notificationHubPath">The notification hub path.</param>
         /// <returns>A task that represents the asynchronous get job operation</returns>
-        public async Task<NotificationHubJob> SubmitNotificationHubJobAsync(NotificationHubJob job, string notificationHubPath)
+        public Task<NotificationHubJob> SubmitNotificationHubJobAsync(NotificationHubJob job, string notificationHubPath)
+        {
+            return SubmitNotificationHubJobAsync(job, notificationHubPath, CancellationToken.None);
+        }
+
+        /// <summary>Submits the notification hub job asynchronously.</summary>
+        /// <param name="job">The job to submit.</param>
+        /// <param name="notificationHubPath">The notification hub path.</param>\
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous get job operation</returns>
+        public async Task<NotificationHubJob> SubmitNotificationHubJobAsync(NotificationHubJob job, string notificationHubPath, CancellationToken cancellationToken)
         {
             if (job == null)
             {
@@ -500,7 +584,7 @@ namespace Microsoft.Azure.NotificationHubs
                  httpRequestMessage.Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(xmlBody)));
 
                  return httpRequestMessage;
-             }).ConfigureAwait(false))
+             }, cancellationToken).ConfigureAwait(false))
             {
                 var xmlResponse = await GetXmlContent(response).ConfigureAwait(false);
                 return GetModelFromResponse<NotificationHubJob>(xmlResponse);
@@ -511,7 +595,17 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="jobId">The job identifier.</param>
         /// <param name="notificationHubPath">The notification hub path.</param>
         /// <returns>A task that represents the asynchronous get job operation</returns>
-        public async Task<NotificationHubJob> GetNotificationHubJobAsync(string jobId, string notificationHubPath)
+        public Task<NotificationHubJob> GetNotificationHubJobAsync(string jobId, string notificationHubPath)
+        {
+            return GetNotificationHubJobAsync(jobId, notificationHubPath, CancellationToken.None);
+        }
+
+        /// <summary>Gets the notification hub job asynchronously.</summary>
+        /// <param name="jobId">The job identifier.</param>
+        /// <param name="notificationHubPath">The notification hub path.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous get job operation</returns>
+        public async Task<NotificationHubJob> GetNotificationHubJobAsync(string jobId, string notificationHubPath, CancellationToken cancellationToken)
         {
             var requestUri = new UriBuilder(Address)
             {
@@ -525,17 +619,27 @@ namespace Microsoft.Azure.NotificationHubs
                  var httpRequestMessage = CreateHttpRequest(HttpMethod.Get, requestUri.Uri);
 
                  return httpRequestMessage;
-             }).ConfigureAwait(false))
+             }, cancellationToken).ConfigureAwait(false))
             {
                 var xmlResponse = await GetXmlContent(response).ConfigureAwait(false);
                 return GetModelFromResponse<NotificationHubJob>(xmlResponse);
             };
         }
 
+
         /// <summary>Gets the notification hub jobs asynchronously.</summary>
         /// <param name="notificationHubPath">The notification hub path.</param>
         /// <returns>A task that represents the asynchronous get jobs operation</returns>
-        public async Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync(string notificationHubPath)
+        public Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync(string notificationHubPath)
+        {
+            return GetNotificationHubJobsAsync(notificationHubPath, CancellationToken.None);
+        }
+
+        /// <summary>Gets the notification hub jobs asynchronously.</summary>
+        /// <param name="notificationHubPath">The notification hub path.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous get jobs operation</returns>
+        public async Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync(string notificationHubPath, CancellationToken cancellationToken)
         {
             var requestUri = new UriBuilder(Address)
             {
@@ -544,7 +648,7 @@ namespace Microsoft.Azure.NotificationHubs
                 Query = $"api-version={ApiVersion}"
             };
 
-            using (var response = await SendAsync(() => CreateHttpRequest(HttpMethod.Get, requestUri.Uri)).ConfigureAwait(false))
+            using (var response = await SendAsync(() => CreateHttpRequest(HttpMethod.Get, requestUri.Uri), cancellationToken).ConfigureAwait(false))
             {
                 var result = new List<NotificationHubJob>();
                 using (var xmlReader = XmlReader.Create(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), new XmlReaderSettings { Async = true }))
@@ -631,14 +735,15 @@ namespace Microsoft.Azure.NotificationHubs
 
             return httpRequestMessage;
         }
-        private async Task<HttpResponseMessage> SendAsync(Func<HttpRequestMessage> generateHttpRequestMessage)
+
+        private async Task<HttpResponseMessage> SendAsync(Func<HttpRequestMessage> generateHttpRequestMessage, CancellationToken cancellationToken)
         {
             var trackingId = Guid.NewGuid().ToString();
 
             var httpRequestMessage = generateHttpRequestMessage();
             httpRequestMessage.Headers.Add(TrackingIdHeaderKey, trackingId);
 
-            var response = await _httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
+            var response = await _httpClient.SendAsync(httpRequestMessage, cancellationToken).ConfigureAwait(false);
             response.Headers.Add(TrackingIdHeaderKey, trackingId);
 
             if (response.IsSuccessStatusCode)

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -59,12 +59,12 @@ namespace Microsoft.Azure.NotificationHubs
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new ArgumentNullException("connectionString");
+                throw new ArgumentNullException(nameof(connectionString));
             }
 
             if (string.IsNullOrWhiteSpace(notificationHubPath))
             {
-                throw new ArgumentNullException("notificationHubPath");
+                throw new ArgumentNullException(nameof(notificationHubPath));
             }
 
             _notificationHubPath = notificationHubPath;
@@ -169,7 +169,21 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload)
         {
-            return SendWindowsNativeNotificationAsync(windowsNativePayload, string.Empty);
+            return SendWindowsNativeNotificationAsync(windowsNativePayload, string.Empty, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a Windows native notification. To specify headers for WNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="windowsNativePayload">The Windows native payload. This can be used to send any valid WNS notification, 
+        /// including Tile, Toast, and Badge values, as described in the WNS documentation.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload, CancellationToken cancellationToken)
+        {
+            return SendWindowsNativeNotificationAsync(windowsNativePayload, string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -182,7 +196,21 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload, string tagExpression)
         {
-            return SendNotificationAsync(new WindowsNotification(windowsNativePayload), tagExpression);
+            return SendNotificationAsync(new WindowsNotification(windowsNativePayload), tagExpression, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a Windows native notification to a tag expression (a single tag "tag" is a valid tag expression). To specify headers for WNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="windowsNativePayload">The Windows native payload. This can be used to send any valid WNS notification, including Tile, Toast, and Badge values, as described in the WNS documentation.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new WindowsNotification(windowsNativePayload), tagExpression, cancellationToken);
         }
 
         /// <summary>
@@ -195,7 +223,21 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload, IEnumerable<string> tags)
         {
-            return SendNotificationAsync(new WindowsNotification(windowsNativePayload), tags);
+            return SendWindowsNativeNotificationAsync(windowsNativePayload, tags, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a Windows native notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||"). To specify headers for WNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="windowsNativePayload">The Windows native payload. This can be used to send any valid WNS notification, including Tile, Toast, and Badge values, as described in the WNS documentation.</param>
+        /// <param name="tags">A non-empty set of tags (max 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendWindowsNativeNotificationAsync(string windowsNativePayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new WindowsNotification(windowsNativePayload), tags, cancellationToken);
         }
 
         /// <summary>
@@ -209,12 +251,27 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public Task<NotificationHubJob> GetNotificationHubJobAsync(string jobId)
         {
+            return GetNotificationHubJobAsync(jobId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Given a jobId, returns the associated <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />. This method
+        /// is used to get the status of the job to see if that job completed, failed, or is still in progress.
+        /// This API is only available for Standard namespaces.
+        /// </summary>
+        /// <param name="jobId">The jobId is returned after creating a new job using <see cref="Microsoft.Azure.NotificationHubs.NotificationHubClient.SubmitNotificationHubJobAsync(NotificationHubJob)" />.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The current state of the <see cref="Microsoft.Azure.NotificationHubs.NotificationHubClient.SubmitNotificationHubJobAsync(NotificationHubJob)" />.
+        /// </returns>
+        public Task<NotificationHubJob> GetNotificationHubJobAsync(string jobId, CancellationToken cancellationToken)
+        {
             if (jobId == null)
             {
                 throw new ArgumentNullException(nameof(jobId));
             }
 
-            return _namespaceManager.GetNotificationHubJobAsync(jobId, _notificationHubPath);
+            return _namespaceManager.GetNotificationHubJobAsync(jobId, _notificationHubPath, cancellationToken);
         }
 
         /// <summary>
@@ -225,9 +282,23 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The current state of the <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />s.
         /// </returns>
-        public async Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync()
+        public Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync()
         {
-            return await _namespaceManager.GetNotificationHubJobsAsync(_notificationHubPath);
+            return GetNotificationHubJobsAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Returns all known <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />s. This method
+        /// is used to get the status of all job to see if those jobs completed, failed, or are still in progress.
+        /// This API is only available for Standard namespaces.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The current state of the <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />s.
+        /// </returns>
+        public async Task<IEnumerable<NotificationHubJob>> GetNotificationHubJobsAsync(CancellationToken cancellationToken)
+        {
+            return await _namespaceManager.GetNotificationHubJobsAsync(_notificationHubPath, cancellationToken);
         }
 
         /// <summary>
@@ -241,7 +312,22 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         public Task<NotificationHubJob> SubmitNotificationHubJobAsync(NotificationHubJob job)
         {
-            return _namespaceManager.SubmitNotificationHubJobAsync(job, _notificationHubPath);            
+            return SubmitNotificationHubJobAsync(job, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />. This API is only
+        /// available for Standard namespaces.
+        /// </summary>
+        /// <param name="job">The <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" /> to
+        /// export registrations, import registrations, or create registrations.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The submitted <see cref="Microsoft.Azure.NotificationHubs.NotificationHubJob" />s.
+        /// </returns>
+        public Task<NotificationHubJob> SubmitNotificationHubJobAsync(NotificationHubJob job, CancellationToken cancellationToken)
+        {
+            return _namespaceManager.SubmitNotificationHubJobAsync(job, _notificationHubPath, cancellationToken);
         }
 
         /// <summary>
@@ -256,6 +342,21 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendAppleNativeNotificationAsync(string jsonPayload)
         {
             return SendAppleNativeNotificationAsync(jsonPayload, string.Empty);
+        }
+
+        /// <summary>
+        /// Sends an Apple native notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
+        /// Documentation on the APNS payload can be found
+        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAppleNativeNotificationAsync(string jsonPayload, CancellationToken cancellationToken)
+        {
+            return SendAppleNativeNotificationAsync(jsonPayload, string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -274,6 +375,22 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Asynchronously sends an Apple native notification to a tag expression (a single tag "tag" is a valid tag expression). To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
+        /// Documentation on the APNS payload can be found
+        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAppleNativeNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new AppleNotification(jsonPayload), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
         /// Asynchronously sends an Apple native notification to a non-empty set of tags (maximum 20). This is equivalent to a tagged expression with boolean ORs ("||"). To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
@@ -289,6 +406,22 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Asynchronously sends an Apple native notification to a non-empty set of tags (maximum 20). This is equivalent to a tagged expression with boolean ORs ("||"). To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
+        /// Documentation on the APNS payload can be found
+        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAppleNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new AppleNotification(jsonPayload), tags, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends a template notification.
         /// </summary>
         /// <param name="properties">The properties to apply to the template.</param>
@@ -298,6 +431,19 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendTemplateNotificationAsync(IDictionary<string, string> properties)
         {
             return SendTemplateNotificationAsync(properties, string.Empty);
+        }
+
+        /// <summary>
+        /// Sends a template notification.
+        /// </summary>
+        /// <param name="properties">The properties to apply to the template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendTemplateNotificationAsync(IDictionary<string, string> properties, CancellationToken cancellationToken)
+        {
+            return SendTemplateNotificationAsync(properties, string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -314,6 +460,20 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends a template notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="properties">The properties to apply to the template.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendTemplateNotificationAsync(IDictionary<string, string> properties, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new TemplateNotification(properties), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends a template notification to a non-empty set of tags (maximum 20). This is equivalent to a tag expression with boolean ORs ("||").
         /// </summary>
         /// <param name="properties">The properties to apply to the template.</param>
@@ -324,6 +484,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendTemplateNotificationAsync(IDictionary<string, string> properties, IEnumerable<string> tags)
         {
             return SendNotificationAsync(new TemplateNotification(properties), tags);
+        }
+
+        /// <summary>
+        /// Sends a template notification to a non-empty set of tags (maximum 20). This is equivalent to a tag expression with boolean ORs ("||").
+        /// </summary>
+        /// <param name="properties">The properties to apply to the template.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendTemplateNotificationAsync(IDictionary<string, string> properties, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new TemplateNotification(properties), tags, cancellationToken);
         }
 
         /// <summary>
@@ -380,6 +554,19 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends Firebase Cloud Messaging (FCM) native notification.
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, CancellationToken cancellationToken)
+        {
+            return SendFcmNativeNotificationAsync(jsonPayload, string.Empty, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends FCM native notification to a tag expression (a single tag "tag" is a valid tag expression).
         /// </summary>
         /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
@@ -390,6 +577,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, string tagExpression)
         {
             return SendNotificationAsync(new FcmNotification(jsonPayload), tagExpression);
+        }
+
+        /// <summary>
+        /// Sends FCM native notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new FcmNotification(jsonPayload), tagExpression, cancellationToken);
         }
 
         /// <summary>
@@ -406,6 +607,20 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends a FCM native notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||").
+        /// </summary>
+        /// <param name="jsonPayload">The JSON payload. Documentation on proper formatting of a FCM message can be found <a href="https://firebase.google.com/docs/cloud-messaging/send-message">here</a>.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendFcmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new FcmNotification(jsonPayload), tags, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends a Baidu native notification.
         /// </summary>
         /// <param name="message">This is a json request. Baidu documents the format for the json <a href="http://push.baidu.com/doc/restapi/restapi">here</a>.</param>
@@ -415,6 +630,19 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message)
         {
             return SendNotificationAsync(new BaiduNotification(message), string.Empty);
+        }
+
+        /// <summary>
+        /// Sends a Baidu native notification.
+        /// </summary>
+        /// <param name="message">This is a json request. Baidu documents the format for the json <a href="http://push.baidu.com/doc/restapi/restapi">here</a>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BaiduNotification(message), string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -434,6 +662,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// Sends Baidu native notification to a tag expression (a single tag "tag" is a valid tag expression).
         /// </summary>
         /// <param name="message">This is a json request. Baidu documents the format for the json <a href="http://push.baidu.com/doc/restapi/restapi">here</a>.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BaiduNotification(message), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends Baidu native notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="message">This is a json request. Baidu documents the format for the json <a href="http://push.baidu.com/doc/restapi/restapi">here</a>.</param>
         /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
@@ -441,6 +683,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message, IEnumerable<string> tags)
         {
             return SendNotificationAsync(new BaiduNotification(message), tags);
+        }
+
+        /// <summary>
+        /// Sends Baidu native notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="message">This is a json request. Baidu documents the format for the json <a href="http://push.baidu.com/doc/restapi/restapi">here</a>.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BaiduNotification(message), tags, cancellationToken);
         }
 
         /// <summary>
@@ -453,6 +709,19 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendAdmNativeNotificationAsync(string jsonPayload)
         {
             return SendAdmNativeNotificationAsync(jsonPayload, string.Empty);
+        }
+
+        /// <summary>
+        /// Sends the Amazon Device Messaging (ADM) native notification.
+        /// </summary>
+        /// <param name="jsonPayload">A valid, ADM JSON payload, described in detail <a href="https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message#Message Payloads and Uniqueness">here</a>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAdmNativeNotificationAsync(string jsonPayload, CancellationToken cancellationToken)
+        {
+            return SendAdmNativeNotificationAsync(jsonPayload, string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -472,6 +741,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// Sends the Amazon Device Messaging (ADM) native notification.
         /// </summary>
         /// <param name="jsonPayload">A valid, ADM JSON payload, described in detail <a href="https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message#Message Payloads and Uniqueness">here</a>.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAdmNativeNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new AdmNotification(jsonPayload), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends the Amazon Device Messaging (ADM) native notification.
+        /// </summary>
+        /// <param name="jsonPayload">A valid, ADM JSON payload, described in detail <a href="https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message#Message Payloads and Uniqueness">here</a>.</param>
         /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
@@ -479,6 +762,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendAdmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags)
         {
             return SendNotificationAsync(new AdmNotification(jsonPayload), tags);
+        }
+
+        /// <summary>
+        /// Sends the Amazon Device Messaging (ADM) native notification.
+        /// </summary>
+        /// <param name="jsonPayload">A valid, ADM JSON payload, described in detail <a href="https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message#Message Payloads and Uniqueness">here</a>.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendAdmNativeNotificationAsync(string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new AdmNotification(jsonPayload), tags, cancellationToken);
         }
 
         /// <summary>
@@ -491,6 +788,19 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<NotificationOutcome> SendMpnsNativeNotificationAsync(string nativePayload)
         {
             return SendMpnsNativeNotificationAsync(nativePayload, string.Empty);
+        }
+
+        /// <summary>
+        /// Sends a Microsoft Push Notification Service (MPNS) native notification. To specify headers for MPNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="nativePayload">The native payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendMpnsNativeNotificationAsync(string nativePayload, CancellationToken cancellationToken)
+        {
+            return SendMpnsNativeNotificationAsync(nativePayload, string.Empty, cancellationToken);
         }
 
         /// <summary>
@@ -507,6 +817,20 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends a Microsoft Push Notification Service (MPNS) native notification to a tag expression (a single tag "tag" is a valid tag expression). To specify headers for MPNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="nativePayload">The native payload.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendMpnsNativeNotificationAsync(string nativePayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new MpnsNotification(nativePayload), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends a Microsoft Push Notification Service (MPNS) native notification to a non-empty set of tags (maximum 20). This is equivalent to a tag expression with boolean ORs ("||"). To specify headers for MPNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
         /// </summary>
         /// <param name="nativePayload">The notification payload.</param>
@@ -520,6 +844,20 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends a Microsoft Push Notification Service (MPNS) native notification to a non-empty set of tags (maximum 20). This is equivalent to a tag expression with boolean ORs ("||"). To specify headers for MPNS, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="nativePayload">The notification payload.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendMpnsNativeNotificationAsync(string nativePayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new MpnsNotification(nativePayload), tags, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends a notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||").
         /// </summary>
         /// <param name="notification">The notification to send.</param>
@@ -529,12 +867,26 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">notification</exception>
         public Task<NotificationOutcome> SendNotificationAsync(Notification notification)
         {
+            return SendNotificationAsync(notification, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||").
+        /// </summary>
+        /// <param name="notification">The notification to send.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">notification</exception>
+        public Task<NotificationOutcome> SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
-                throw new ArgumentNullException("notification");
+                throw new ArgumentNullException(nameof(notification));
             }
 
-            return SendNotificationImplAsync(notification, notification.tag, null, CancellationToken.None);
+            return SendNotificationImplAsync(notification, notification.tag, null, cancellationToken);
         }
 
         /// <summary>
@@ -549,17 +901,33 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentException">notification.Tag property should be null</exception>
         public Task<NotificationOutcome> SendNotificationAsync(Notification notification, string tagExpression)
         {
+            return SendNotificationAsync(notification, tagExpression, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a notification to a tag expression (a single tag "tag" is a valid tag expression).
+        /// </summary>
+        /// <param name="notification">The notification to send.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">notification</exception>
+        /// <exception cref="System.ArgumentException">notification.Tag property should be null</exception>
+        public Task<NotificationOutcome> SendNotificationAsync(Notification notification, string tagExpression, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
-                throw new ArgumentNullException("notification");
+                throw new ArgumentNullException(nameof(notification));
             }
 
             if (notification.tag != null)
             {
-                throw new ArgumentException("notification.Tag property should be null");
+                throw new ArgumentException($"{nameof(notification)}.{nameof(notification.tag)} property should be null");
             }
 
-            return SendNotificationImplAsync(notification, tagExpression, null, CancellationToken.None);
+            return SendNotificationImplAsync(notification, tagExpression, null, cancellationToken);
         }
 
         /// <summary>
@@ -580,28 +948,50 @@ namespace Microsoft.Azure.NotificationHubs
         /// </exception>
         public Task<NotificationOutcome> SendNotificationAsync(Notification notification, IEnumerable<string> tags)
         {
+            return SendNotificationAsync(notification, tags, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a notification to a non-empty set of tags (max 20). This is equivalent to a tag expression with boolean ORs ("||").
+        /// </summary>
+        /// <param name="notification">The notification to send.</param>
+        /// <param name="tags">A non-empty set of tags (max 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when notification or tag object is null
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// notification.Tag property should not be null
+        /// or
+        /// tags argument should contain at least one tag
+        /// </exception>
+        public Task<NotificationOutcome> SendNotificationAsync(Notification notification, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
-                throw new ArgumentNullException("notification");
+                throw new ArgumentNullException(nameof(notification));
             }
 
             if (notification.tag != null)
             {
-                throw new ArgumentException("notification.Tag property should be null");
+                throw new ArgumentException($"{nameof(notification)}.{nameof(notification.tag)} property should be null");
             }
 
             if (tags == null)
             {
-                throw new ArgumentNullException("tags");
+                throw new ArgumentNullException(nameof(tags));
             }
 
             if (tags.Count() == 0)
             {
-                throw new ArgumentException("tags argument should contain at least one tag");
+                throw new ArgumentException($"{nameof(tags)} argument should contain at least one value");
             }
 
             string tagExpression = string.Join("||", tags);
-            return SendNotificationImplAsync(notification, tagExpression, null, CancellationToken.None);
+            return SendNotificationImplAsync(notification, tagExpression, null, cancellationToken);
         }
 
         /// <summary>
@@ -614,11 +1004,27 @@ namespace Microsoft.Azure.NotificationHubs
         /// The result of the Send operation, as expressed by a <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" />.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">notificationId</exception>
-        public async Task<NotificationDetails> GetNotificationOutcomeDetailsAsync(string notificationId)
+        public Task<NotificationDetails> GetNotificationOutcomeDetailsAsync(string notificationId)
+        {
+            return GetNotificationOutcomeDetailsAsync(notificationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Retrieves the results of a Send* operation. This can retrieve intermediate results if the send is being processed
+        /// or final results if the Send* has completed. This API can only be called for Standard namespaces.
+        /// </summary>
+        /// <param name="notificationId"><see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome.NotificationId" /> which was returned
+        /// when calling Send*.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The result of the Send operation, as expressed by a <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" />.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">notificationId</exception>
+        public async Task<NotificationDetails> GetNotificationOutcomeDetailsAsync(string notificationId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(notificationId))
             {
-                throw new ArgumentNullException("notificationId");
+                throw new ArgumentNullException(nameof(notificationId), "value may not be null, and must contain more than just whitespace");
             }
 
             var requestUri = GetGenericRequestUriBuilder();
@@ -626,7 +1032,7 @@ namespace Microsoft.Azure.NotificationHubs
 
             using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
             {
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK,  CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
                 {
                     using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
                     {
@@ -640,14 +1046,24 @@ namespace Microsoft.Azure.NotificationHubs
         /// Gets the feedback container URI asynchronously.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public async Task<Uri> GetFeedbackContainerUriAsync()
+        public Task<Uri> GetFeedbackContainerUriAsync()
+        {
+            return GetFeedbackContainerUriAsync(CancellationToken.None);
+        }
+        
+        /// <summary>
+        /// Gets the feedback container URI asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task<Uri> GetFeedbackContainerUriAsync(CancellationToken cancellationToken)
         {
             var requestUri = GetGenericRequestUriBuilder();
             requestUri.Path += "feedbackcontainer";
 
             using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
             {
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
                 {
                     return new Uri(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
                 }
@@ -670,16 +1086,29 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when the installation object is null</exception>
         /// <exception cref="System.InvalidOperationException">InstallationId must be specified</exception>
-        public async Task CreateOrUpdateInstallationAsync(Installation installation)
+        public Task CreateOrUpdateInstallationAsync(Installation installation)
+        {
+            return CreateOrUpdateInstallationAsync(installation, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates or updates a device installation asynchronously.
+        /// </summary>
+        /// <param name="installation">The device installation object.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when the installation object is null</exception>
+        /// <exception cref="System.InvalidOperationException">InstallationId must be specified</exception>
+        public async Task CreateOrUpdateInstallationAsync(Installation installation, CancellationToken cancellationToken)
         {
             if (installation==null)
             {
-                throw new ArgumentNullException("installation");
+                throw new ArgumentNullException(nameof(installation));
             }
 
             if (string.IsNullOrWhiteSpace(installation.InstallationId))
             {
-                throw new InvalidOperationException("InstallationId must be specified");
+                throw new InvalidOperationException($"{nameof(installation)}.{nameof(installation.InstallationId)} must be specified");
             }
 
             var requestUri = GetGenericRequestUriBuilder();
@@ -689,7 +1118,7 @@ namespace Microsoft.Azure.NotificationHubs
             {
                 request.Content = new StringContent(installation.ToJson(), Encoding.UTF8, "application/json");
 
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
@@ -715,7 +1144,23 @@ namespace Microsoft.Azure.NotificationHubs
         /// Thrown when the installationId or operations object is null
         /// </exception>
         /// <exception cref="System.InvalidOperationException">Thrown when the operations list is empty</exception>
-        public async Task PatchInstallationAsync(string installationId, IList<PartialUpdateOperation> operations)
+        public Task PatchInstallationAsync(string installationId, IList<PartialUpdateOperation> operations)
+        {
+            return PatchInstallationAsync(installationId, operations, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Patches the installation asynchronously.
+        /// </summary>
+        /// <param name="installationId">The installation identifier.</param>
+        /// <param name="operations">The collection of update operations.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when the installationId or operations object is null
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when the operations list is empty</exception>
+        public async Task PatchInstallationAsync(string installationId, IList<PartialUpdateOperation> operations, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(installationId))
             {
@@ -724,12 +1169,12 @@ namespace Microsoft.Azure.NotificationHubs
 
             if (operations == null)
             {
-                throw new ArgumentNullException("operations");
+                throw new ArgumentNullException(nameof(operations));
             }
 
             if (operations.Count == 0)
             {
-                throw new InvalidOperationException("Operations list is empty");
+                throw new InvalidOperationException($"{nameof(operations)} list is empty");
             }
 
             var requestUri = GetGenericRequestUriBuilder();
@@ -739,11 +1184,10 @@ namespace Microsoft.Azure.NotificationHubs
             {
                 request.Content = new StringContent(operations.ToJson(), Encoding.UTF8, "application/json-patch+json");
 
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
-            
         }
 
         /// <summary>
@@ -761,7 +1205,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="installationId">The installation identifier.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when the installationId object is null</exception>
-        public async Task DeleteInstallationAsync(string installationId)
+        public Task DeleteInstallationAsync(string installationId)
+        {
+            return DeleteInstallationAsync(installationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the installation asynchronously.
+        /// </summary>
+        /// <param name="installationId">The installation identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when the installationId object is null</exception>
+        public async Task DeleteInstallationAsync(string installationId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(installationId))
             {
@@ -773,7 +1229,7 @@ namespace Microsoft.Azure.NotificationHubs
 
             using (var request = CreateHttpRequest(HttpMethod.Delete, requestUri.Uri, out var trackingId))
             {
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.NoContent, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.NoContent, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
@@ -794,7 +1250,18 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="installationId">The installation identifier.</param>
         /// <returns>Returns a task which is true if the installation exists, else false.</returns>
-        public async Task<bool> InstallationExistsAsync(string installationId)
+        public Task<bool> InstallationExistsAsync(string installationId)
+        {
+            return InstallationExistsAsync(installationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Determines whether the given installation exists based upon the installation identifier.
+        /// </summary>
+        /// <param name="installationId">The installation identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>Returns a task which is true if the installation exists, else false.</returns>
+        public async Task<bool> InstallationExistsAsync(string installationId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(installationId))
             {
@@ -806,7 +1273,7 @@ namespace Microsoft.Azure.NotificationHubs
 
             using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
             {
-                using (var response = await SendRequestAsync(request, trackingId, new [] { HttpStatusCode.OK, HttpStatusCode.NotFound }, CancellationToken.None))
+                using (var response = await SendRequestAsync(request, trackingId, new [] { HttpStatusCode.OK, HttpStatusCode.NotFound }, cancellationToken))
                 {
                     return response.StatusCode == HttpStatusCode.OK;
                 }
@@ -829,7 +1296,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="installationId">The installation identifier.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when the installationId object is null</exception>
-        public async Task<Installation> GetInstallationAsync(string installationId)
+        public Task<Installation> GetInstallationAsync(string installationId)
+        {
+            return GetInstallationAsync(installationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Gets the installation asynchronously.
+        /// </summary>
+        /// <param name="installationId">The installation identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when the installationId object is null</exception>
+        public async Task<Installation> GetInstallationAsync(string installationId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(installationId))
             {
@@ -841,7 +1320,7 @@ namespace Microsoft.Azure.NotificationHubs
 
             using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
             {
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
                 {
                     var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     return JsonConvert.DeserializeObject<Installation>(responseContent);
@@ -855,7 +1334,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task object representing the asynchronous operation.
         /// </returns>
-        public async Task<string> CreateRegistrationIdAsync()
+        public Task<string> CreateRegistrationIdAsync()
+        {
+            return CreateRegistrationIdAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a registration identifier.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public async Task<string> CreateRegistrationIdAsync(CancellationToken cancellationToken)
         {
             var requestUri = GetGenericRequestUriBuilder();
             requestUri.Path += "registrationids";
@@ -863,7 +1354,7 @@ namespace Microsoft.Azure.NotificationHubs
             string registrationId = null;
 
             using (var request = CreateHttpRequest(HttpMethod.Post, requestUri.Uri, out var trackingId))
-            using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.Created, CancellationToken.None).ConfigureAwait(false))
+            using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.Created, cancellationToken).ConfigureAwait(false))
             {
                 if (response.Headers.Location != null)
                 {
@@ -894,6 +1385,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously creates Windows native registration.
         /// </summary>
         /// <param name="channelUri">The channel URI.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<WindowsRegistrationDescription> CreateWindowsNativeRegistrationAsync(string channelUri, CancellationToken cancellationToken)
+        {
+            return CreateWindowsNativeRegistrationAsync(channelUri, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates Windows native registration.
+        /// </summary>
+        /// <param name="channelUri">The channel URI.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -901,6 +1405,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<WindowsRegistrationDescription> CreateWindowsNativeRegistrationAsync(string channelUri, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new WindowsRegistrationDescription(new Uri(channelUri), tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates Windows native registration.
+        /// </summary>
+        /// <param name="channelUri">The channel URI.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<WindowsRegistrationDescription> CreateWindowsNativeRegistrationAsync(string channelUri, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new WindowsRegistrationDescription(new Uri(channelUri), tags), cancellationToken);
         }
 
         /// <summary>
@@ -921,6 +1439,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="channelUri">The channel URI.</param>
         /// <param name="xmlTemplate">The XML template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<WindowsTemplateRegistrationDescription> CreateWindowsTemplateRegistrationAsync(string channelUri, string xmlTemplate, CancellationToken cancellationToken)
+        {
+            return CreateWindowsTemplateRegistrationAsync(channelUri, xmlTemplate, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates Windows template registration.
+        /// </summary>
+        /// <param name="channelUri">The channel URI.</param>
+        /// <param name="xmlTemplate">The XML template.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -929,6 +1461,22 @@ namespace Microsoft.Azure.NotificationHubs
             string channelUri, string xmlTemplate, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new WindowsTemplateRegistrationDescription(new Uri(channelUri), xmlTemplate, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates Windows template registration.
+        /// </summary>
+        /// <param name="channelUri">The channel URI.</param>
+        /// <param name="xmlTemplate">The XML template.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<WindowsTemplateRegistrationDescription> CreateWindowsTemplateRegistrationAsync(
+            string channelUri, string xmlTemplate, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new WindowsTemplateRegistrationDescription(new Uri(channelUri), xmlTemplate, tags), cancellationToken);
         }
 
         /// <summary>
@@ -947,6 +1495,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously creates an Apple native registration.
         /// </summary>
         /// <param name="deviceToken">The device token.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<AppleRegistrationDescription> CreateAppleNativeRegistrationAsync(string deviceToken, CancellationToken cancellationToken)
+        {
+            return CreateAppleNativeRegistrationAsync(deviceToken, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates an Apple native registration.
+        /// </summary>
+        /// <param name="deviceToken">The device token.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -954,6 +1515,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<AppleRegistrationDescription> CreateAppleNativeRegistrationAsync(string deviceToken, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new AppleRegistrationDescription(deviceToken, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates an Apple native registration.
+        /// </summary>
+        /// <param name="deviceToken">The device token.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<AppleRegistrationDescription> CreateAppleNativeRegistrationAsync(string deviceToken, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new AppleRegistrationDescription(deviceToken, tags), cancellationToken);
         }
 
         /// <summary>
@@ -974,6 +1549,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="deviceToken">The device token.</param>
         /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<AppleTemplateRegistrationDescription> CreateAppleTemplateRegistrationAsync(string deviceToken, string jsonPayload, CancellationToken cancellationToken)
+        {
+            return CreateAppleTemplateRegistrationAsync(deviceToken, jsonPayload, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates an Apple template registration. To specify additional properties at creation, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.CreateRegistrationAsync``1(``0)" /> method.
+        /// </summary>
+        /// <param name="deviceToken">The device token.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -981,6 +1570,21 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<AppleTemplateRegistrationDescription> CreateAppleTemplateRegistrationAsync(string deviceToken, string jsonPayload, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new AppleTemplateRegistrationDescription(deviceToken, jsonPayload, tags));
+        }
+        
+        /// <summary>
+        /// Asynchronously creates an Apple template registration. To specify additional properties at creation, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.CreateRegistrationAsync``1(``0)" /> method.
+        /// </summary>
+        /// <param name="deviceToken">The device token.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<AppleTemplateRegistrationDescription> CreateAppleTemplateRegistrationAsync(string deviceToken, string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new AppleTemplateRegistrationDescription(deviceToken, jsonPayload, tags), cancellationToken);
         }
 
         /// <summary>
@@ -999,6 +1603,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously creates a native administrative registration.
         /// </summary>
         /// <param name="admRegistrationId">The administrative registration identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public Task<AdmRegistrationDescription> CreateAdmNativeRegistrationAsync(string admRegistrationId, CancellationToken cancellationToken)
+        {
+            return CreateAdmNativeRegistrationAsync(admRegistrationId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a native administrative registration.
+        /// </summary>
+        /// <param name="admRegistrationId">The administrative registration identifier.</param>
         /// <param name="tags">The tags for the registration.</param>
         /// <returns>
         /// The task object representing the asynchronous operation.
@@ -1006,6 +1623,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<AdmRegistrationDescription> CreateAdmNativeRegistrationAsync(string admRegistrationId, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new AdmRegistrationDescription(admRegistrationId, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates a native administrative registration.
+        /// </summary>
+        /// <param name="admRegistrationId">The administrative registration identifier.</param>
+        /// <param name="tags">The tags for the registration.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public Task<AdmRegistrationDescription> CreateAdmNativeRegistrationAsync(string admRegistrationId, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new AdmRegistrationDescription(admRegistrationId, tags), cancellationToken);
         }
 
         /// <summary>
@@ -1026,6 +1657,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="admRegistrationId">The administrative registration identifier.</param>
         /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public Task<AdmTemplateRegistrationDescription> CreateAdmTemplateRegistrationAsync(string admRegistrationId, string jsonPayload, CancellationToken cancellationToken)
+        {
+            return CreateAdmTemplateRegistrationAsync(admRegistrationId, jsonPayload, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates an administrative template registration.
+        /// </summary>
+        /// <param name="admRegistrationId">The administrative registration identifier.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task object representing the asynchronous operation.
@@ -1033,6 +1678,21 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<AdmTemplateRegistrationDescription> CreateAdmTemplateRegistrationAsync(string admRegistrationId, string jsonPayload, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new AdmTemplateRegistrationDescription(admRegistrationId, jsonPayload, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates an administrative template registration.
+        /// </summary>
+        /// <param name="admRegistrationId">The administrative registration identifier.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        public Task<AdmTemplateRegistrationDescription> CreateAdmTemplateRegistrationAsync(string admRegistrationId, string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new AdmTemplateRegistrationDescription(admRegistrationId, jsonPayload, tags), cancellationToken);
         }
 
         /// <summary>
@@ -1107,6 +1767,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously creates FCM native registration.
         /// </summary>
         /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmRegistrationDescription> CreateFcmNativeRegistrationAsync(string fcmRegistrationId, CancellationToken cancellationToken)
+        {
+            return CreateFcmNativeRegistrationAsync(fcmRegistrationId, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM native registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -1114,6 +1787,20 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<FcmRegistrationDescription> CreateFcmNativeRegistrationAsync(string fcmRegistrationId, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new FcmRegistrationDescription(fcmRegistrationId, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM native registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmRegistrationDescription> CreateFcmNativeRegistrationAsync(string fcmRegistrationId, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new FcmRegistrationDescription(fcmRegistrationId, tags), cancellationToken);
         }
 
         /// <summary>
@@ -1134,6 +1821,20 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="fcmRegistrationId">The FCM registration ID.</param>
         /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmTemplateRegistrationDescription> CreateFcmTemplateRegistrationAsync(string fcmRegistrationId, string jsonPayload, CancellationToken cancellationToken)
+        {
+            return CreateFcmTemplateRegistrationAsync(fcmRegistrationId, jsonPayload, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM template registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
         /// <param name="tags">The tags.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -1141,6 +1842,21 @@ namespace Microsoft.Azure.NotificationHubs
         public Task<FcmTemplateRegistrationDescription> CreateFcmTemplateRegistrationAsync(string fcmRegistrationId, string jsonPayload, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new FcmTemplateRegistrationDescription(fcmRegistrationId, jsonPayload, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates FCM template registration.
+        /// </summary>
+        /// <param name="fcmRegistrationId">The FCM registration ID.</param>
+        /// <param name="jsonPayload">The JSON payload.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<FcmTemplateRegistrationDescription> CreateFcmTemplateRegistrationAsync(string fcmRegistrationId, string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new FcmTemplateRegistrationDescription(fcmRegistrationId, jsonPayload, tags), cancellationToken);
         }
 
         #region Baidu Create Registration
@@ -1251,7 +1967,6 @@ namespace Microsoft.Azure.NotificationHubs
             return CreateRegistrationAsync(new MpnsTemplateRegistrationDescription(new Uri(channelUri), xmlTemplate, tags));
         }
 
-
         /// <summary>
         /// Asynchronously creates a registration.
         /// </summary>
@@ -1267,18 +1982,37 @@ namespace Microsoft.Azure.NotificationHubs
         /// </exception>
         public Task<T> CreateRegistrationAsync<T>(T registration) where T : RegistrationDescription
         {
+            return CreateRegistrationAsync(registration, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a registration.
+        /// </summary>
+        /// <typeparam name="T">The type of registration.</typeparam>
+        /// <param name="registration">The registration to create.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">
+        /// NotificationHubPath in RegistrationDescription is not valid.
+        /// or
+        /// RegistrationId should be null or empty
+        /// </exception>
+        public Task<T> CreateRegistrationAsync<T>(T registration, CancellationToken cancellationToken) where T : RegistrationDescription
+        {
             if (!string.IsNullOrWhiteSpace(registration.NotificationHubPath) &&
                 registration.NotificationHubPath != _notificationHubPath)
             {
-                throw new ArgumentException("NotificationHubPath in RegistrationDescription is not valid.");
+                throw new ArgumentException($"{nameof(registration)}.{nameof(registration.NotificationHubPath)} in {nameof(RegistrationDescription)} is not valid.");
             }
 
             if (!string.IsNullOrWhiteSpace(registration.RegistrationId))
             {
-                throw new ArgumentException("RegistrationId should be null or empty");
+                throw new ArgumentException($"{nameof(registration)}.{nameof(registration.RegistrationId)} should be null or empty");
             }
 
-            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.Create, CancellationToken.None);
+            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.Create, cancellationToken);
         }
 
         /// <summary>
@@ -1294,17 +2028,34 @@ namespace Microsoft.Azure.NotificationHubs
         /// </exception>
         public Task<T> UpdateRegistrationAsync<T>(T registration) where T : RegistrationDescription
         {
+            return UpdateRegistrationAsync(registration, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously updates the registration.
+        /// </summary>
+        /// <typeparam name="T">The type of registration.</typeparam>
+        /// <param name="registration">The registration to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// A task that will complete when the update finishes.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when RegistrationId or ETag object is null
+        /// </exception>
+        public Task<T> UpdateRegistrationAsync<T>(T registration, CancellationToken cancellationToken) where T : RegistrationDescription
+        {
             if (string.IsNullOrWhiteSpace(registration.RegistrationId))
             {
-                throw new ArgumentNullException("RegistrationId");
+                throw new ArgumentNullException($"{nameof(registration)}.{nameof(registration.RegistrationId)}");
             }
 
             if (string.IsNullOrWhiteSpace(registration.ETag))
             {
-                throw new ArgumentNullException("ETag");
+                throw new ArgumentNullException($"{nameof(registration)}.{nameof(registration.ETag)}");
             }
 
-            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.Update, CancellationToken.None);
+            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.Update, cancellationToken);
         }
 
         /// <summary>
@@ -1318,12 +2069,27 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">Thrown when RegistrationId object is null</exception>
         public Task<T> CreateOrUpdateRegistrationAsync<T>(T registration) where T : RegistrationDescription
         {
+            return CreateOrUpdateRegistrationAsync(registration, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously creates or updates the client registration.
+        /// </summary>
+        /// <typeparam name="T">The type of registration.</typeparam>
+        /// <param name="registration">The registration to be created or updated.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task object representing the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when RegistrationId object is null</exception>
+        public Task<T> CreateOrUpdateRegistrationAsync<T>(T registration, CancellationToken cancellationToken) where T : RegistrationDescription
+        {
             if (string.IsNullOrWhiteSpace(registration.RegistrationId))
             {
-                throw new ArgumentNullException("RegistrationId");
+                throw new ArgumentNullException($"{nameof(registration)}.{nameof(registration.RegistrationId)}");
             }
 
-            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.CreateOrUpdate, CancellationToken.None);
+            return CreateOrUpdateRegistrationImplAsync(registration, EntityOperatonType.CreateOrUpdate, cancellationToken);
         }
 
         /// <summary>
@@ -1337,12 +2103,27 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">Thrown when registrationId is null</exception>
         public Task<TRegistrationDescription> GetRegistrationAsync<TRegistrationDescription>(string registrationId) where TRegistrationDescription : RegistrationDescription
         {
+            return GetRegistrationAsync<TRegistrationDescription>(registrationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves a registration with a given ID. The type of the registration depends upon the specified TRegistrationDescription parameter.
+        /// </summary>
+        /// <typeparam name="TRegistrationDescription">The type of registration description.</typeparam>
+        /// <param name="registrationId">The registration ID.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when registrationId is null</exception>
+        public Task<TRegistrationDescription> GetRegistrationAsync<TRegistrationDescription>(string registrationId, CancellationToken cancellationToken) where TRegistrationDescription : RegistrationDescription
+        {
             if (string.IsNullOrWhiteSpace(registrationId))
             {
-                throw new ArgumentNullException("registrationId");
+                throw new ArgumentNullException(nameof(registrationId));
             }
 
-            return GetEntityImplAsync<TRegistrationDescription>("registrations", registrationId, CancellationToken.None);
+            return GetEntityImplAsync<TRegistrationDescription>("registrations", registrationId, cancellationToken);
         }
 
         /// <summary>
@@ -1350,7 +2131,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="top">The location of the registration.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top)
         {
@@ -1360,19 +2141,46 @@ namespace Microsoft.Azure.NotificationHubs
         /// <summary>
         /// Asynchronously retrieves all registrations in this notification hub.
         /// </summary>
+        /// <param name="top">The location of the registration.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top, CancellationToken cancellationToken)
+        {
+            return GetAllRegistrationsImplAsync(null, top, null, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves all registrations in this notification hub.
+        /// </summary>
         /// <param name="continuationToken">The continuation token.</param>
         /// <param name="top">The location of the registration.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top)
+        {
+            return GetAllRegistrationsAsync(continuationToken, top, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves all registrations in this notification hub.
+        /// </summary>
+        /// <param name="continuationToken">The continuation token.</param>
+        /// <param name="top">The location of the registration.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top, CancellationToken cancellationToken)
         {
             if (continuationToken == null)
             {
                 throw new ArgumentNullException(nameof(continuationToken));
             }
 
-            return GetAllRegistrationsImplAsync(continuationToken, top, null, null, CancellationToken.None);
+            return GetAllRegistrationsImplAsync(continuationToken, top, null, null, cancellationToken);
         }
 
         /// <summary>
@@ -1381,7 +2189,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="pnsHandle">The PNS handle.</param>
         /// <param name="top">The location of the registration.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top)
         {
@@ -1392,20 +2200,50 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously gets the registrations by channel.
         /// </summary>
         /// <param name="pnsHandle">The PNS handle.</param>
+        /// <param name="top">The location of the registration.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top, CancellationToken cancellationToken)
+        {
+            return GetAllRegistrationsImplAsync(null, top, pnsHandle, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the registrations by channel.
+        /// </summary>
+        /// <param name="pnsHandle">The PNS handle.</param>
         /// <param name="continuationToken">The continuation token.</param>
         /// <param name="top">The location of the registration.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
         public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top)
         {
+            return GetRegistrationsByChannelAsync(pnsHandle, continuationToken, top, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the registrations by channel.
+        /// </summary>
+        /// <param name="pnsHandle">The PNS handle.</param>
+        /// <param name="continuationToken">The continuation token.</param>
+        /// <param name="top">The location of the registration.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrWhiteSpace(pnsHandle))
             {
-                throw new ArgumentNullException("pnsHandle");
+                throw new ArgumentNullException(nameof(pnsHandle));
             }
 
-            return GetAllRegistrationsImplAsync(continuationToken, top, pnsHandle, null, CancellationToken.None);
+            return GetAllRegistrationsImplAsync(continuationToken, top, pnsHandle, null, cancellationToken);
         }
 
         /// <summary>
@@ -1418,12 +2256,26 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">Thrown when registration object is null.</exception>
         public Task DeleteRegistrationAsync(RegistrationDescription registration)
         {
+            return DeleteRegistrationAsync(registration, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the registration.
+        /// </summary>
+        /// <param name="registration">The registration to delete.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when registration object is null.</exception>
+        public Task DeleteRegistrationAsync(RegistrationDescription registration, CancellationToken cancellationToken)
+        {
             if (registration == null)
             {
-                throw new ArgumentNullException("registration");
+                throw new ArgumentNullException(nameof(registration));
             }
 
-            return DeleteRegistrationAsync(registration.RegistrationId, registration.ETag);
+            return DeleteRegistrationAsync(registration.RegistrationId, registration.ETag, cancellationToken);
         }
 
         /// <summary>
@@ -1442,6 +2294,19 @@ namespace Microsoft.Azure.NotificationHubs
         /// Asynchronously deletes the registration.
         /// </summary>
         /// <param name="registrationId">The registration ID.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task DeleteRegistrationAsync(string registrationId, CancellationToken cancellationToken)
+        {
+            return DeleteRegistrationAsync(registrationId, "*", cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the registration.
+        /// </summary>
+        /// <param name="registrationId">The registration ID.</param>
         /// <param name="etag">The entity tag.</param>
         /// <returns>
         /// The task that completes the asynchronous operation.
@@ -1449,12 +2314,27 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">registrationId</exception>
         public Task DeleteRegistrationAsync(string registrationId, string etag)
         {
+            return DeleteRegistrationAsync(registrationId, etag, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the registration.
+        /// </summary>
+        /// <param name="registrationId">The registration ID.</param>
+        /// <param name="etag">The entity tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">registrationId</exception>
+        public Task DeleteRegistrationAsync(string registrationId, string etag, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrWhiteSpace(registrationId))
             {
-                throw new ArgumentNullException("registrationId");
+                throw new ArgumentNullException(nameof(registrationId));
             }
 
-            return DeleteRegistrationImplAsync(registrationId, etag, CancellationToken.None);
+            return DeleteRegistrationImplAsync(registrationId, etag, cancellationToken);
         }
 
         /// <summary>
@@ -1465,17 +2345,31 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
-        public async Task DeleteRegistrationsByChannelAsync(string pnsHandle)
+        public Task DeleteRegistrationsByChannelAsync(string pnsHandle)
+        {
+            return DeleteRegistrationsByChannelAsync(pnsHandle, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes the registrations by channel.
+        /// </summary>
+        /// <param name="pnsHandle">The PNS handle.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
+        public async Task DeleteRegistrationsByChannelAsync(string pnsHandle, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(pnsHandle))
             {
-                throw new ArgumentNullException("pnsHandle");
+                throw new ArgumentNullException(nameof(pnsHandle));
             }
 
-            var registrationsToDelete = await GetRegistrationsByChannelAsync(pnsHandle, EntitiesPerRequest).ConfigureAwait(false);
+            var registrationsToDelete = await GetRegistrationsByChannelAsync(pnsHandle, EntitiesPerRequest, cancellationToken).ConfigureAwait(false);
             do
             {
-                var deletionTasks = registrationsToDelete.Select(r => DeleteRegistrationImplAsync(r.RegistrationId, null, CancellationToken.None));
+                var deletionTasks = registrationsToDelete.Select(r => DeleteRegistrationImplAsync(r.RegistrationId, null, cancellationToken));
                 await Task.WhenAll(deletionTasks).ConfigureAwait(false);
             }
             while (!string.IsNullOrEmpty(registrationsToDelete.ContinuationToken));
@@ -1488,9 +2382,25 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public async Task<bool> RegistrationExistsAsync(string registrationId)
+        public Task<bool> RegistrationExistsAsync(string registrationId)
         {
-            return await GetRegistrationAsync<RegistrationDescription>(registrationId).ConfigureAwait(false) != null;
+            return RegistrationExistsAsync(registrationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously indicates that the registration already exists.
+        /// </summary>
+        /// <param name="registrationId">The registration ID.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public async Task<bool> RegistrationExistsAsync(string registrationId, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(registrationId))
+                throw new ArgumentNullException(nameof(registrationId));
+
+            return await GetEntityImplAsync<RegistrationDescription>("registrations", registrationId, cancellationToken, throwIfNotFound: false) != null;
         }
 
         /// <summary>
@@ -1499,16 +2409,30 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="tag">The tag.</param>
         /// <param name="top">The location where to get the registrations.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top)
         {
+            return GetRegistrationsByTagAsync(tag, top, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the registrations by tag.
+        /// </summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="top">The location where to get the registrations.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrWhiteSpace(tag))
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
-            return GetAllRegistrationsImplAsync(null, top, null, tag, CancellationToken.None);
+            return GetAllRegistrationsImplAsync(null, top, null, tag, cancellationToken);
         }
 
         /// <summary>
@@ -1518,17 +2442,33 @@ namespace Microsoft.Azure.NotificationHubs
         /// <param name="continuationToken">The continuation token.</param>
         /// <param name="top">The location where to get the registrations.</param>
         /// <returns>
-        /// The task that completes the asynchronous operation.
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
         public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top)
         {
+            return GetRegistrationsByTagAsync(tag, continuationToken, top, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the registrations by tag.
+        /// </summary>
+        /// <param name="tag">The tag.</param>
+        /// <param name="continuationToken">The continuation token.</param>
+        /// <param name="top">The location where to get the registrations.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
+        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top, CancellationToken cancellationToken)
+        {
             if (string.IsNullOrWhiteSpace(tag))
             {
-                throw new ArgumentNullException("tag");
+                throw new ArgumentNullException(nameof(tag));
             }
 
-            return GetAllRegistrationsImplAsync(continuationToken, top, null, tag, CancellationToken.None);
+            return GetAllRegistrationsImplAsync(continuationToken, top, null, tag, cancellationToken);
         }
 
         /// <summary>
@@ -1539,12 +2479,24 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>A task that represents the asynchronous operation.</returns>
         public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime)
         {
+            return ScheduleNotificationAsync(notification, scheduledTime, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Schedules the notification asynchronously.
+        /// </summary>
+        /// <param name="notification">The notification.</param>
+        /// <param name="scheduledTime">The scheduled time.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
                 throw new ArgumentNullException(nameof(notification));
             }
 
-            return SendScheduledNotificationImplAsync(notification, scheduledTime, null, CancellationToken.None);
+            return SendScheduledNotificationImplAsync(notification, scheduledTime, null, cancellationToken);
         }
 
         /// <summary>
@@ -1558,6 +2510,21 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentException">tags argument should contain at least one tag</exception>
         public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime, IEnumerable<string> tags)
         {
+            return ScheduleNotificationAsync(notification, scheduledTime, tags, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Schedules the notification asynchronously.
+        /// </summary>
+        /// <param name="notification">The notification.</param>
+        /// <param name="scheduledTime">The scheduled time.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when tags object is null</exception>
+        /// <exception cref="System.ArgumentException">tags argument should contain at least one tag</exception>
+        public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
                 throw new ArgumentNullException(nameof(notification));
@@ -1565,16 +2532,16 @@ namespace Microsoft.Azure.NotificationHubs
 
             if (tags == null)
             {
-                throw new ArgumentNullException("tags");
+                throw new ArgumentNullException(nameof(tags));
             }
 
             if (tags.Count() == 0)
             {
-                throw new ArgumentException("tags argument should contain at least one tag");
+                throw new ArgumentException(message: $"{nameof(tags)} argument should contain at least one value", paramName: nameof(tags));
             }
 
             string tagExpression = String.Join("||", tags);
-            return SendScheduledNotificationImplAsync(notification, scheduledTime, tagExpression, CancellationToken.None);
+            return SendScheduledNotificationImplAsync(notification, scheduledTime, tagExpression, cancellationToken);
         }
 
         /// <summary>
@@ -1586,12 +2553,25 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>A task that represents the asynchronous operation.</returns>
         public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime, string tagExpression)
         {
+            return ScheduleNotificationAsync(notification, scheduledTime, tagExpression, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Schedules the notification asynchronously.
+        /// </summary>
+        /// <param name="notification">The notification.</param>
+        /// <param name="scheduledTime">The scheduled time.</param>
+        /// <param name="tagExpression">The tag expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public Task<ScheduledNotification> ScheduleNotificationAsync(Notification notification, DateTimeOffset scheduledTime, string tagExpression, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
                 throw new ArgumentNullException(nameof(notification));
             }
 
-            return SendScheduledNotificationImplAsync(notification, scheduledTime, tagExpression, CancellationToken.None);
+            return SendScheduledNotificationImplAsync(notification, scheduledTime, tagExpression, cancellationToken);
         }
 
         /// <summary>
@@ -1599,7 +2579,18 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="scheduledNotificationId">The scheduled notification identifier.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        public async Task CancelNotificationAsync(string scheduledNotificationId)
+        public Task CancelNotificationAsync(string scheduledNotificationId)
+        {
+            return CancelNotificationAsync(scheduledNotificationId, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Cancels the notification asynchronously.
+        /// </summary>
+        /// <param name="scheduledNotificationId">The scheduled notification identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public async Task CancelNotificationAsync(string scheduledNotificationId, CancellationToken cancellationToken)
         {
             if (scheduledNotificationId == null)
             {
@@ -1610,7 +2601,7 @@ namespace Microsoft.Azure.NotificationHubs
             requestUri.Path += $"schedulednotifications/{scheduledNotificationId}";
 
             using (var request = CreateHttpRequest(HttpMethod.Delete, requestUri.Uri, out var trackingId))
-            using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, CancellationToken.None).ConfigureAwait(false))
+            using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
             {
             }
         }
@@ -1629,17 +2620,35 @@ namespace Microsoft.Azure.NotificationHubs
         /// </exception>
         public Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, string deviceHandle)
         {
+            return SendDirectNotificationAsync(notification, deviceHandle, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a notification directly to a deviceHandle (a valid token as expressed by the Notification type).
+        /// Users of this API do not use Registrations or Installations. Instead, users of this API manage all devices
+        /// on their own and use Azure Notification Hub solely as a pass through service to communicate with
+        /// the various Push Notification Services.
+        /// </summary>
+        /// <param name="notification">A instance of a Notification, identifying which Push Notification Service to send to.</param>
+        /// <param name="deviceHandle">A valid device identifier.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when notification or deviceHandle object is null
+        /// </exception>
+        public Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, string deviceHandle, CancellationToken cancellationToken)
+        {
             if (notification == null)
             {
-                throw new ArgumentNullException("notification");
+                throw new ArgumentNullException(nameof(notification));
             }
 
             if (string.IsNullOrEmpty(deviceHandle))
             {
-                throw new ArgumentNullException("deviceHandle");
+                throw new ArgumentNullException(nameof(deviceHandle));
             }
 
-            return SendNotificationImplAsync(notification, null, deviceHandle, CancellationToken.None);
+            return SendNotificationImplAsync(notification, null, deviceHandle, cancellationToken);
         }
 
         /// <summary>
@@ -1654,21 +2663,39 @@ namespace Microsoft.Azure.NotificationHubs
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when notification or deviceHandles object is null
         /// </exception>
-        public async Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, IList<string> deviceHandles)
+        public Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, IList<string> deviceHandles)
+        {
+            return SendDirectNotificationAsync(notification, deviceHandles, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Sends a notification directly to all devices listed in deviceHandles (a valid tokens as expressed by the Notification type).
+        /// Users of this API do not use Registrations or Installations. Instead, users of this API manage all devices
+        /// on their own and use Azure Notification Hub solely as a pass through service to communicate with
+        /// the various Push Notification Services.
+        /// </summary>
+        /// <param name="notification">A instance of a Notification, identifying which Push Notification Service to send to.</param>
+        /// <param name="deviceHandles">A list of valid device identifiers.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when notification or deviceHandles object is null
+        /// </exception>
+        public async Task<NotificationOutcome> SendDirectNotificationAsync(Notification notification, IList<string> deviceHandles, CancellationToken cancellationToken)
         {
             if (notification == null)
             {
-                throw new ArgumentNullException("notification");
+                throw new ArgumentNullException(nameof(notification));
             }
 
             if (deviceHandles==null)
             {
-                throw new ArgumentNullException("deviceHandles");
+                throw new ArgumentNullException(nameof(deviceHandles));
             }
 
             if (deviceHandles.Count == 0)
             {
-                throw new ArgumentException("deviceHandles");
+                throw new ArgumentException(message: $"{nameof(deviceHandles)} should contain at least one value", paramName: nameof(deviceHandles));
             }
 
             var requestUri = GetGenericRequestUriBuilder();
@@ -1699,7 +2726,7 @@ namespace Microsoft.Azure.NotificationHubs
 
                 request.Content = content;
 
-                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.Created, CancellationToken.None).ConfigureAwait(false))
+                using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.Created, cancellationToken).ConfigureAwait(false))
                 {
                     return new NotificationOutcome()
                     {
@@ -1971,19 +2998,29 @@ namespace Microsoft.Azure.NotificationHubs
             }
         }
 
-        private async Task<TEntity> GetEntityImplAsync<TEntity>(string entityCollection, string entityId, CancellationToken cancellationToken) where TEntity : EntityDescription
+        private async Task<TEntity> GetEntityImplAsync<TEntity>(string entityCollection, string entityId, CancellationToken cancellationToken, bool throwIfNotFound = true) where TEntity : EntityDescription
         {
             var requestUri = GetGenericRequestUriBuilder();
             requestUri.Path += $"{entityCollection}/{entityId}";
 
-            using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
-            using (var response = await SendRequestAsync(request, trackingId, HttpStatusCode.OK, cancellationToken).ConfigureAwait(false))
-            {
-                using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-                {
-                    return await ReadEntityAsync<TEntity>(responseStream).ConfigureAwait(false);
-                }
+            HttpStatusCode[] successfulResponseStatuses;
+            if (throwIfNotFound)
+                successfulResponseStatuses = new [] { HttpStatusCode.OK };
+            else
+                successfulResponseStatuses = new [] { HttpStatusCode.OK, HttpStatusCode.NotFound };
 
+            using (var request = CreateHttpRequest(HttpMethod.Get, requestUri.Uri, out var trackingId))
+            {
+                using (var response = await SendRequestAsync(request, trackingId, successfulResponseStatuses, cancellationToken).ConfigureAwait(false))
+                {
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                        return null;
+
+                    using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        return await ReadEntityAsync<TEntity>(responseStream).ConfigureAwait(false);
+                    }
+                }
             }
         }
 

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubConnectionStringBuilder.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubConnectionStringBuilder.cs
@@ -99,5 +99,14 @@ namespace Microsoft.Azure.NotificationHubs
                 throw new ArgumentException(exception.Message, "connectionString", exception);
             }
         }
+
+        /// <summary>
+        /// Returns string representation of parsed connection string
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"Endpoint={Endpoint};SharedAccessKeyName={SharedAccessKeyName};SharedAccessKey={SharedAccessKey}";
+        }
     }
 }

--- a/src/Microsoft.Azure.NotificationHubs/NotificationOutcome.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationOutcome.cs
@@ -30,32 +30,44 @@ namespace Microsoft.Azure.NotificationHubs
         public NotificationOutcomeState State { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the success value of the outcome.
+        /// Gets or sets the number of devices that successfully received the notification.
         /// </summary>
         /// 
         /// <returns>
-        /// The success value of the outcome.
+        /// The number of devices that successfully received the notification.
         /// </returns>
+        /// <remarks>
+        /// The property contains value only when <see cref="NotificationHubClient.EnableTestSend"/> property is turned on for troubleshooting purposes.
+        /// </remarks>
+        /// <seealso cref="NotificationHubClient.EnableTestSend"/>
         [DataMember(Name = ManagementStrings.Success, IsRequired = true, Order = 1001, EmitDefaultValue = true)]
         public long Success { get; set; }
 
         /// <summary>
-        /// Gets or sets the failure value of the outcome.
+        /// Gets or sets the number of devices that failed to receive a notification.
         /// </summary>
         /// 
         /// <returns>
-        /// The failure value of the outcome.
+        /// The number of devices that failed to receive a notification.
         /// </returns>
+        /// <remarks>
+        /// The property contains value only when <see cref="NotificationHubClient.EnableTestSend"/> property is turned on for troubleshooting purposes.
+        /// </remarks>
+        /// <seealso cref="NotificationHubClient.EnableTestSend"/>
         [DataMember(Name = ManagementStrings.Failure, IsRequired = true, Order = 1002, EmitDefaultValue = true)]
         public long Failure { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of notification outcome results.
+        /// Gets or sets the list of notification outcome results for each device registered with the hub, to which this notification was sent.
         /// </summary>
         /// 
         /// <returns>
-        /// The list of notification outcome results.
+        /// The list of notification outcome results for each device registered with the hub, to which this notification was sent.
         /// </returns>
+        /// <remarks>
+        /// The property contains value only when <see cref="NotificationHubClient.EnableTestSend"/> property is turned on for troubleshooting purposes.
+        /// </remarks>
+        /// <seealso cref="NotificationHubClient.EnableTestSend"/>
         [DataMember(Name = ManagementStrings.Results, IsRequired = true, Order = 1003, EmitDefaultValue = true)]
         public List<RegistrationResult> Results { get; set; }
 
@@ -64,8 +76,11 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// 
         /// <returns>
-        /// notification ID.
+        /// Notification ID.
         /// </returns>
+        /// <remarks>
+        /// The property contains value only when using Standard tier Notification Hubs.
+        /// </remarks>
         public string NotificationId { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Azure.NotificationHubs/NotificationPlatform.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationPlatform.cs
@@ -50,5 +50,11 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         [EnumMember(Value = "adm")]
         Adm=5,
+
+        /// <summary>
+        /// Baidu Installation Platform
+        /// </summary>
+        [EnumMember(Value = "baidu")]
+        Baidu=6,
     }
 }

--- a/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
-        /// Gets or sets the ETag associated with this description.
+        /// Gets the ETag associated with this description.
         /// </summary>
         /// 
         /// <returns>
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.NotificationHubs
         public string ETag { get; internal set; }
 
         /// <summary>
-        /// Gets or sets the expiration time of the registration.
+        /// Gets the expiration time of the registration.
         /// </summary>
         /// 
         /// <returns>


### PR DESCRIPTION
Merged master to fix merge conflicts found in management-apis branch. This involved plumbing through a cancellation token overload for every namespace manager function.

Found and issue with MockData in the netframework tests, so also fixed the csproj reference so it builds/tests now.