### PR TITLE
Fix parameters order

### DIFF
--- a/Samples/UwpSample/UwpSample/App.xaml.cs
+++ b/Samples/UwpSample/UwpSample/App.xaml.cs
@@ -96,7 +96,7 @@ namespace UwpSample
         {
             var channel = await PushNotificationChannelManager.CreatePushNotificationChannelForApplicationAsync();
 
-            var hub = new NotificationHubClient(Secrets.HubName, Secrets.HubConnectionString);
+            var hub = new NotificationHubClient(Secrets.HubConnectionString, Secrets.HubName);
             await hub.CreateOrUpdateInstallationAsync(new Installation
             {
                 Platform = NotificationPlatform.Wns,


### PR DESCRIPTION
There is bug with parameters order. First is connection string and second is hub name