### PR TITLE
Change to mockable interface for CollectionQueryResult

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/CollectionQueryResult.cs
+++ b/src/Microsoft.Azure.NotificationHubs/CollectionQueryResult.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.NotificationHubs
     /// Represents a collection query result.
     /// </summary>
     /// <typeparam name="T">The type of the result.</typeparam>
-    public sealed class CollectionQueryResult<T> : IEnumerable<T> where T : EntityDescription
+    public sealed class CollectionQueryResult<T> : ICollectionQueryResult<T> where T : EntityDescription
     {
         private IEnumerable<T> results;
 

--- a/src/Microsoft.Azure.NotificationHubs/ICollectionQueryResult.cs
+++ b/src/Microsoft.Azure.NotificationHubs/ICollectionQueryResult.cs
@@ -1,0 +1,26 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved. 
+// Licensed under the MIT License. See License.txt in the project root for 
+// license information.
+//------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Azure.NotificationHubs.Messaging;
+
+namespace Microsoft.Azure.NotificationHubs
+{
+        /// <summary>
+    /// Represents a collection query result.
+    /// </summary>
+    /// <typeparam name="T">The type of the result.</typeparam>
+    public interface ICollectionQueryResult<T> : IEnumerable<T> where T : EntityDescription
+    {
+        /// <summary>
+        /// Gets the continuation token.
+        /// </summary>
+        /// <value>
+        /// The continuation token, which is null or empty when there is no additional data available in the query.
+        /// </value>
+        string ContinuationToken { get; }
+    }
+}

--- a/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
@@ -667,7 +667,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top);
 
         /// <summary>
         /// Asynchronously retrieves all registrations in this notification hub.
@@ -677,7 +677,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously retrieves all registrations in this notification hub.
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top);
 
         /// <summary>
         /// Asynchronously retrieves all registrations in this notification hub.
@@ -698,7 +698,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns the base URI for the notification hub client.
@@ -845,7 +845,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top);
 
         /// <summary>
         /// Asynchronously gets the registrations by channel.
@@ -856,7 +856,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously gets the registrations by channel.
@@ -868,7 +868,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top);
 
         /// <summary>
         /// Asynchronously gets the registrations by channel.
@@ -881,7 +881,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously gets the registrations by tag.
@@ -891,7 +891,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top);
 
         /// <summary>
         /// Asynchronously gets the registrations by tag.
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously gets the registrations by tag.
@@ -914,7 +914,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top);
 
         /// <summary>
         /// Asynchronously gets the registrations by tag.
@@ -927,7 +927,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
-        Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top, CancellationToken cancellationToken);
+        Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top, CancellationToken cancellationToken);
 
         /// <summary>
         /// Determines whether the given installation exists based upon the installation identifier.

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -2169,7 +2169,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top)
         {
             return GetAllRegistrationsImplAsync(null, top, null, null, CancellationToken.None);
         }
@@ -2182,7 +2182,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(int top, CancellationToken cancellationToken)
         {
             return GetAllRegistrationsImplAsync(null, top, null, null, cancellationToken);
         }
@@ -2195,7 +2195,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top)
         {
             return GetAllRegistrationsAsync(continuationToken, top, CancellationToken.None);
         }
@@ -2209,7 +2209,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsAsync(string continuationToken, int top, CancellationToken cancellationToken)
         {
             if (continuationToken == null)
             {
@@ -2227,7 +2227,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top)
         {
             return GetAllRegistrationsImplAsync(null, top, pnsHandle, null, CancellationToken.None);
         }
@@ -2241,7 +2241,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, int top, CancellationToken cancellationToken)
         {
             return GetAllRegistrationsImplAsync(null, top, pnsHandle, null, cancellationToken);
         }
@@ -2256,7 +2256,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top)
         {
             return GetRegistrationsByChannelAsync(pnsHandle, continuationToken, top, CancellationToken.None);
         }
@@ -2272,7 +2272,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">pnsHandle</exception>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByChannelAsync(string pnsHandle, string continuationToken, int top, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(pnsHandle))
             {
@@ -2447,7 +2447,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top)
         {
             return GetRegistrationsByTagAsync(tag, top, CancellationToken.None);
         }
@@ -2461,7 +2461,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, int top, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(tag))
             {
@@ -2481,7 +2481,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top)
         {
             return GetRegistrationsByTagAsync(tag, continuationToken, top, CancellationToken.None);
         }
@@ -2497,7 +2497,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// The task that completes the asynchronous operation, which will contain a null or empty continuation token when there is no additional data available in the query.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">Thrown when tag object is null</exception>
-        public Task<CollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top, CancellationToken cancellationToken)
+        public Task<ICollectionQueryResult<RegistrationDescription>> GetRegistrationsByTagAsync(string tag, string continuationToken, int top, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(tag))
             {
@@ -2980,7 +2980,7 @@ namespace Microsoft.Azure.NotificationHubs
             }, cancellationToken);
         }
 
-        private async Task<CollectionQueryResult<TEntity>> GetAllEntitiesImplAsync<TEntity>(UriBuilder requestUri, string continuationToken, int top, CancellationToken cancellationToken) where TEntity : EntityDescription
+        private async Task<ICollectionQueryResult<TEntity>> GetAllEntitiesImplAsync<TEntity>(UriBuilder requestUri, string continuationToken, int top, CancellationToken cancellationToken) where TEntity : EntityDescription
         {
             if (top > 0)
             {
@@ -3010,7 +3010,7 @@ namespace Microsoft.Azure.NotificationHubs
 
         }
 
-        private Task<CollectionQueryResult<RegistrationDescription>> GetAllRegistrationsImplAsync(string continuationToken, int top, string deviceHandle, string tag, CancellationToken cancellationToken)
+        private Task<ICollectionQueryResult<RegistrationDescription>> GetAllRegistrationsImplAsync(string continuationToken, int top, string deviceHandle, string tag, CancellationToken cancellationToken)
         {
             var requestUri = GetGenericRequestUriBuilder();
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Creates an interface that encompasses the `CollectionQueryResult<T>` as `ICollectionQueryResult<T>` which then allows for mockability instead of having a class with an internal constructor.

## Related PRs or issues

#205 

## Misc

N/A