### PR TITLE
{AzureNotificationHub} fixes Azure/azure-sdk-for-net#29233

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
         /// Documentation on the APNS payload can be found
-        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">here</a>.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
         /// Documentation on the APNS payload can be found
-        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">here</a>.</param>
         /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
         /// Documentation on the APNS payload can be found
-        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">here</a>.</param>
         /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
         /// Documentation on the APNS payload can be found
-        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">here</a>.</param>
         /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
         /// <returns>
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// </summary>
         /// <param name="jsonPayload">This is a valid Apple Push Notification Service (APNS) payload.
         /// Documentation on the APNS payload can be found
-        /// <a href="https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html">here</a>.</param>
+        /// <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">here</a>.</param>
         /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
         /// <returns>


### PR DESCRIPTION
The link to https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html is broken.

Updated Link for Documentation on the APNS payload: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification

fixes Azure/azure-sdk-for-net#29233

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.