### PR TITLE
Add missing strings for FCM V1 to resx file

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/FcmV1RegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/FcmV1RegistrationDescription.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.NotificationHubs
         {
             if (string.IsNullOrWhiteSpace(FcmV1RegistrationId))
             {
-                throw new InvalidDataContractException(SRClient.FCMV1RegistrationInvalidId);
+                throw new InvalidDataContractException(SRClient.FcmV1RegistrationInvalidId);
             }
         }
 

--- a/src/Microsoft.Azure.NotificationHubs/SRClient.Designer.cs
+++ b/src/Microsoft.Azure.NotificationHubs/SRClient.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.NotificationHubs {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SRClient {
@@ -1211,18 +1211,52 @@ namespace Microsoft.Azure.NotificationHubs {
                 return ResourceManager.GetString("FCMRegistrationInvalidId", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ClientEmail is either not specified or invalid..
+        /// </summary>
+        internal static string FcmV1ClientEmailNotSpecified {
+            get {
+                return ResourceManager.GetString("FcmV1ClientEmailNotSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PrivateKey is either not specified or invalid..
+        /// </summary>
+        internal static string FcmV1PrivateKeyNotSpecified {
+            get {
+                return ResourceManager.GetString("FcmV1PrivateKeyNotSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ProjectId is either not specified or invalid..
+        /// </summary>
+        internal static string FcmV1ProjectIdNotSpecified {
+            get {
+                return ResourceManager.GetString("FcmV1ProjectIdNotSpecified", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to FCM V1 Registration Id is invalid..
         /// </summary>
-        internal static string FCMV1RegistrationInvalidId
-        {
-            get
-            {
-                return ResourceManager.GetString("FCMV1RegistrationInvalidId", resourceCulture);
+        internal static string FcmV1RegistrationInvalidId {
+            get {
+                return ResourceManager.GetString("FcmV1RegistrationInvalidId", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PrivateKey, ProjectId, and ClientEmail are required..
+        /// </summary>
+        internal static string FcmV1RequiredProperties {
+            get {
+                return ResourceManager.GetString("FcmV1RequiredProperties", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The feature &apos;{0}&apos; is not supported with the current configuration..
         /// </summary>
@@ -1231,51 +1265,7 @@ namespace Microsoft.Azure.NotificationHubs {
                 return ResourceManager.GetString("FeatureNotSupported", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Only PrivateKey, ProjectId and ClientEmail are required..
-        /// </summary>
-        internal static string FcmV1RequiredProperties
-        {
-            get
-            {
-                return ResourceManager.GetString("FcmV1RequiredProperties", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to FcmV1PrivateKey is either not specified or invalid..
-        /// </summary>
-        internal static string FcmV1PrivateKeyNotSpecified
-        {
-            get
-            {
-                return ResourceManager.GetString("FcmV1PrivateKeyNotSpecified", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to FcmV1ProjectId is either not specified or invalid..
-        /// </summary>
-        internal static string FcmV1ProjectIdNotSpecified
-        {
-            get
-            {
-                return ResourceManager.GetString("FcmV1ProjectIdNotSpecified", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to FcmV1ClientEmail is either not specified or invalid..
-        /// </summary>
-        internal static string FcmV1ClientEmailNotSpecified
-        {
-            get
-            {
-                return ResourceManager.GetString("FcmV1ClientEmailNotSpecified", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to There are {0} statements defined in the filter action, which exceeds the allowed maximum of {1}..
         /// </summary>
@@ -1365,7 +1355,7 @@ namespace Microsoft.Azure.NotificationHubs {
                 return ResourceManager.GetString("GoogleApiKeyNotSpecified", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The token provider does not support HTTP authorization token..
         /// </summary>

--- a/src/Microsoft.Azure.NotificationHubs/SRClient.resx
+++ b/src/Microsoft.Azure.NotificationHubs/SRClient.resx
@@ -1294,4 +1294,19 @@
   <data name="ServerIsBusy" xml:space="preserve">
     <value>Server is busy.</value>
   </data>
+  <data name="FcmV1ClientEmailNotSpecified" xml:space="preserve">
+    <value>ClientEmail is either not specified or invalid.</value>
+  </data>
+  <data name="FcmV1PrivateKeyNotSpecified" xml:space="preserve">
+    <value>PrivateKey is either not specified or invalid.</value>
+  </data>
+  <data name="FcmV1ProjectIdNotSpecified" xml:space="preserve">
+    <value>ProjectId is either not specified or invalid.</value>
+  </data>
+  <data name="FcmV1RegistrationInvalidId" xml:space="preserve">
+    <value>FCM V1 Registration Id is invalid.</value>
+  </data>
+  <data name="FcmV1RequiredProperties" xml:space="preserve">
+    <value>PrivateKey, ProjectId, and ClientEmail are required.</value>
+  </data>
 </root>


### PR DESCRIPTION
Things to consider before you submit the PR:

* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The error messages for FCM V1 are missing from SRClient.resx. Then the SRClient.Designer.cs file is regenerated, the associated properties are removed as a result. This PR fixes the issue by adding the strings to the resx.