### PR TITLE
Extend web push support

### DIFF
--- a/src/Microsoft.Azure.NotificationHubs/BrowserTemplateRegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/BrowserTemplateRegistrationDescription.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.NotificationHubs.Messaging;
 
 namespace Microsoft.Azure.NotificationHubs
 {
+    [DataContract(Name = ManagementStrings.BrowserTemplateRegistrationDescription, Namespace = ManagementStrings.Namespace)]
     public class BrowserTemplateRegistrationDescription : BrowserRegistrationDescription
     {
         /// <summary>

--- a/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh);
+        Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh);
 
         /// <summary>
         /// Asynchronously creates a browser native registration.
@@ -270,8 +270,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken);
-        
+        Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken);
+
         /// <summary>
         /// Asynchronously creates a browser native registration.
         /// </summary>
@@ -282,8 +282,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags);
-        
+        Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags);
+
         /// <summary>
         /// Asynchronously creates a browser native registration.
         /// </summary>
@@ -295,8 +295,8 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken);
-        
+        Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken);
+
         /// <summary>
         /// Asynchronously creates FCM native registration.
         /// </summary>
@@ -1407,7 +1407,6 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, CancellationToken cancellationToken);
 
-        
         /// <summary>
         /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
         /// </summary>
@@ -1449,7 +1448,7 @@ namespace Microsoft.Azure.NotificationHubs
         ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
         /// </returns>
         Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken);
-        
+
         /// <summary>
         /// Sends a notification directly to all devices listed in deviceHandles (a valid tokens as expressed by the Notification type).
         /// Users of this API do not use Registrations or Installations. Instead, users of this API manage all devices

--- a/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/INotificationHubClient.cs
@@ -250,6 +250,54 @@ namespace Microsoft.Azure.NotificationHubs
         Task<BaiduTemplateRegistrationDescription> CreateBaiduTemplateRegistrationAsync(string userId, string channelId, string jsonPayload, IEnumerable<string> tags);
 
         /// <summary>
+        /// Asynchronously creates a browser native registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh);
+
+        /// <summary>
+        /// Asynchronously creates a browser native registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken);
+        
+        /// <summary>
+        /// Asynchronously creates a browser native registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="tags">The tags.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags);
+        
+        /// <summary>
+        /// Asynchronously creates a browser native registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken);
+        
+        /// <summary>
         /// Asynchronously creates FCM native registration.
         /// </summary>
         /// <param name="fcmRegistrationId">The FCM registration ID.</param>
@@ -1340,6 +1388,68 @@ namespace Microsoft.Azure.NotificationHubs
         /// </returns>
         Task<NotificationOutcome> SendBaiduNativeNotificationAsync(string message, string tagExpression, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload);
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, CancellationToken cancellationToken);
+
+        
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, IEnumerable<string> tags);
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, string tagExpression);
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken);
+        
         /// <summary>
         /// Sends a notification directly to all devices listed in deviceHandles (a valid tokens as expressed by the Notification type).
         /// Users of this API do not use Registrations or Installations. Instead, users of this API manage all devices

--- a/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
@@ -96,11 +96,11 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             this.entirySerializers.Add(
                 typeof(BaiduTemplateRegistrationDescription).Name,
                 this.CreateSerializer<BaiduTemplateRegistrationDescription>());
-            
+
             this.entirySerializers.Add(
                 typeof(BrowserRegistrationDescription).Name,
                 this.CreateSerializer<BrowserRegistrationDescription>());
-            
+
             this.entirySerializers.Add(
                 typeof(BrowserTemplateRegistrationDescription).Name,
                 this.CreateSerializer<BrowserTemplateRegistrationDescription>());
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             {
                 Serialize(description, xmlWriter);
             }
-            
+
             return stringBuilder.ToString();
         }
 

--- a/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
+++ b/src/Microsoft.Azure.NotificationHubs/Messaging/EntityDescriptionSerializer.cs
@@ -96,6 +96,14 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             this.entirySerializers.Add(
                 typeof(BaiduTemplateRegistrationDescription).Name,
                 this.CreateSerializer<BaiduTemplateRegistrationDescription>());
+            
+            this.entirySerializers.Add(
+                typeof(BrowserRegistrationDescription).Name,
+                this.CreateSerializer<BrowserRegistrationDescription>());
+            
+            this.entirySerializers.Add(
+                typeof(BrowserTemplateRegistrationDescription).Name,
+                this.CreateSerializer<BrowserTemplateRegistrationDescription>());
 
             this.entirySerializers.Add(
                 typeof(NotificationHubJob).Name,
@@ -138,7 +146,7 @@ namespace Microsoft.Azure.NotificationHubs.Messaging
             {
                 Serialize(description, xmlWriter);
             }
-
+            
             return stringBuilder.ToString();
         }
 

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -788,6 +788,85 @@ namespace Microsoft.Azure.NotificationHubs
         }
 
         /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload));
+        }
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload), cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, IEnumerable<string> tags)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload), tags);
+        }
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tags">A non-empty set of tags (maximum 20 tags). Each string in the set can contain a single tag.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload), tags, cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, string tagExpression)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload), tagExpression);
+        }
+
+        /// <summary>
+        /// Sends a browser notification. To specify an expiry, use the <see cref="M:Microsoft.Azure.NotificationHubs.NotificationHubClient.SendNotificationAsync(Microsoft.Azure.NotificationHubs.Notification)" /> method.
+        /// </summary>
+        /// <param name="jsonPayload">This is a valid browser push notification payload.</param>
+        /// <param name="tagExpression">A tag expression is any boolean expression constructed using the logical operators AND (&amp;&amp;), OR (||), NOT (!), and round parentheses. For example: (A || B) &amp;&amp; !C. If an expression uses only ORs, it can contain at most 20 tags. Other expressions are limited to 6 tags. Note that a single tag "A" is a valid expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        ///   <see cref="Microsoft.Azure.NotificationHubs.NotificationOutcome" /> which describes the result of the Send operation.
+        /// </returns>
+        public Task<NotificationOutcome> SendBrowserNotificationAsync(string jsonPayload, string tagExpression, CancellationToken cancellationToken)
+        {
+            return SendNotificationAsync(new BrowserNotification(jsonPayload), tagExpression, cancellationToken);
+        }
+
+        /// <summary>
         /// Sends the Amazon Device Messaging (ADM) native notification.
         /// </summary>
         /// <param name="jsonPayload">A valid, ADM JSON payload, described in detail <a href="https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message#Message Payloads and Uniqueness">here</a>.</param>
@@ -2141,6 +2220,66 @@ namespace Microsoft.Azure.NotificationHubs
 
         #endregion
 
+        /// <summary>
+        /// Asynchronously creates browser registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh)
+        {
+            return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }));
+        }
+
+        /// <summary>
+        /// Asynchronously creates browser registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }), cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates browser registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="tags">The tags.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags)
+        {
+            return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }, tags));
+        }
+
+        /// <summary>
+        /// Asynchronously creates browser registration.
+        /// </summary>
+        /// <param name="endpoint">String containing the endpoint associated with the push subscription.</param>
+        /// <param name="auth">Value used to retrieve the authentication secret.</param>
+        /// <param name="p256dh">Value used to retrieve the public key.</param>
+        /// <param name="tags">The tags.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for a task to complete.</param>
+        /// <returns>
+        /// The task that completes the asynchronous operation.
+        /// </returns>
+        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken)
+        {
+            return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }, tags), cancellationToken);
+        }
+        
         /// <summary>
         /// Asynchronously creates MPNS native registration.
         /// </summary>

--- a/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
+++ b/src/Microsoft.Azure.NotificationHubs/NotificationHubClient.cs
@@ -2229,7 +2229,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh)
+        public Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh)
         {
             return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }));
         }
@@ -2244,7 +2244,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken)
+        public Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, CancellationToken cancellationToken)
         {
             return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }), cancellationToken);
         }
@@ -2259,7 +2259,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags)
+        public Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags)
         {
             return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }, tags));
         }
@@ -2275,7 +2275,7 @@ namespace Microsoft.Azure.NotificationHubs
         /// <returns>
         /// The task that completes the asynchronous operation.
         /// </returns>
-        public Task<BrowserRegistrationDescription> CreateBrowserRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken)
+        public Task<BrowserRegistrationDescription> CreateBrowserNativeRegistrationAsync(string endpoint, string auth, string p256dh, IEnumerable<string> tags, CancellationToken cancellationToken)
         {
             return CreateRegistrationAsync(new BrowserRegistrationDescription(new BrowserPushSubscription { Auth = auth, Endpoint = endpoint, P256DH = p256dh }, tags), cancellationToken);
         }

--- a/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
+++ b/src/Microsoft.Azure.NotificationHubs/RegistrationDescription.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.NotificationHubs
     [KnownType(typeof(BaiduTemplateRegistrationDescription))]
     [KnownType(typeof(FcmV1RegistrationDescription))]
     [KnownType(typeof(FcmV1TemplateRegistrationDescription))]
+    [KnownType(typeof(BrowserRegistrationDescription))]
+    [KnownType(typeof(BrowserTemplateRegistrationDescription))]
     public abstract class RegistrationDescription : EntityDescription
     {
         internal const string TemplateRegistrationType = "template";


### PR DESCRIPTION
Hi,
this adds some missing annotations for the recently added BrowserRegistrationDescriptions and registers them with the serializer. Besides that, I added some convenience methods to NotificationHubClient in accordance with the already existing ones.

Things to consider before you submit the PR:

* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Related PRs or issues
#314 

## Misc
"CreateBrowserTemplateRegistrationAsync" methods are currently not added it INotificationHubClient.